### PR TITLE
Fix relation bug

### DIFF
--- a/logpy/facts.py
+++ b/logpy/facts.py
@@ -29,8 +29,28 @@ class Relation(object):
             self.index[key].add(fact)
 
     def __call__(self, *args):
-        def f(s):
-            args2 = reify(args, s)
+        """ Returns an evaluated (callable) goal, which returns a list of
+        substitutions which match args against a fact in the knowledge base.
+
+        *args: the goal to evaluate. This consists of vars and values to
+               match facts against.
+
+        >>> from logpy.facts import Relation
+        >>> from logpy.variable import var
+        >>>
+        >>> x, y = var('x'), var('y')
+        >>> r = Relation()
+        >>> r.add_fact(1, 2, 3)
+        >>> r.add_fact(4, 5, 6)
+        >>> list(r(x, y, 3)({})) == [{y: 2, x: 1}]
+        True
+        >>> list(r(x, 5, y)({})) == [{y: 6, x: 4}]
+        True
+        >>> list(r(x, 42, y)({}))
+        []
+        """
+        def goal(substitution):
+            args2 = reify(args, substitution)
             subsets = [self.index[key] for key in enumerate(args)
                                        if  key in self.index]
             if subsets:     # we are able to reduce the pool early
@@ -44,9 +64,9 @@ class Relation(object):
             assert not any(var in s for var in vars)
 
             return (merge(dict(zip(vars, index(fact, varinds))), s)
-                              for fact in self.facts
+                              for fact in facts
                               if vals == index(fact, valinds))
-        return f
+        return goal
 
     def __str__(self):
         return "Rel: " + self.name

--- a/logpy/facts.py
+++ b/logpy/facts.py
@@ -1,6 +1,8 @@
-from .util import intersection, index
-from .core import conde, reify, isvar
+from .core import reify
+from .unification import unify
+from .util import intersection
 from toolz import merge
+
 
 class Relation(object):
     _id = 0
@@ -57,15 +59,12 @@ class Relation(object):
                 facts = intersection(*sorted(subsets, key=len))
             else:
                 facts = self.facts
-            varinds = [i for i, arg in enumerate(args2) if isvar(arg)]
-            valinds = [i for i, arg in enumerate(args2) if not isvar(arg)]
-            vars = index(args2, varinds)
-            vals = index(args2, valinds)
-            assert not any(var in s for var in vars)
 
-            return (merge(dict(zip(vars, index(fact, varinds))), s)
-                              for fact in facts
-                              if vals == index(fact, valinds))
+            for fact in facts:
+                unified = unify(fact, args2, substitution)
+                if unified != False:
+                    yield merge(unified, substitution)
+
         return goal
 
     def __str__(self):

--- a/logpy/tests/test_facts.py
+++ b/logpy/tests/test_facts.py
@@ -33,3 +33,31 @@ def test_fact():
     assert (2, 3) in rel.facts
     assert (3, 4) in rel.facts
 
+def test_unify_variable_with_itself_should_not_unify():
+    # Regression test for https://github.com/logpy/logpy/issues/33
+    valido = Relation()
+    fact(valido, "a", "b")
+    fact(valido, "b", "a")
+    x = var()
+    assert run(0,x, valido(x,x)) == ()
+
+def test_unify_variable_with_itself_should_unify():
+    valido = Relation()
+    fact(valido, 0, 1)
+    fact(valido, 1, 0)
+    fact(valido, 1, 1)
+    x = var()
+    assert run(0,x, valido(x,x)) == (1,)
+
+def test_unify_tuple():
+    # Tests that adding facts can be unified with unpacked versions of those
+    # facts.
+    valido = Relation()
+    fact(valido, (0, 1))
+    fact(valido, (1, 0))
+    fact(valido, (1, 1))
+    x = var()
+    y = var()
+    assert set(run(0, x, valido((x, y)))) == {0, 1}
+    assert set(run(0, (x, y), valido((x, y)))) == {(0, 1), (1, 0), (1, 1)}
+    assert run(0,x, valido((x,x))) == (1,)

--- a/logpy/tests/test_facts.py
+++ b/logpy/tests/test_facts.py
@@ -58,6 +58,6 @@ def test_unify_tuple():
     fact(valido, (1, 1))
     x = var()
     y = var()
-    assert set(run(0, x, valido((x, y)))) == {0, 1}
-    assert set(run(0, (x, y), valido((x, y)))) == {(0, 1), (1, 0), (1, 1)}
+    assert set(run(0, x, valido((x, y)))) == set([0, 1])
+    assert set(run(0, (x, y), valido((x, y)))) == set([(0, 1), (1, 0), (1, 1)])
     assert run(0,x, valido((x,x))) == (1,)


### PR DESCRIPTION
@skirpichev @mrocklin Fixes #33 if accepted.

## Nature of the bug

In #33, @andrewchambers found two bugs. 

The first was that constraints where a variable was repeated were not being handled correctly. In checking whether the constraint matched a fact in the knowledge base, two assignments were generated, then munged together into a dict, with the second one winning. This led to a constraint `(x, x)` successfully unifying with the fact `('a', 'b')`, which is incorrect.

The second was that in trying to unify a complex goal (a tuple) with a fact, tuples of variables were being interpreted as values (since they failed the `isvar` check). That mean that `((x, y), )` does not unify with the fact `((1, 2), )` when it should.

## Changes
- The fix for both bugs is to replace the attempt to directly match the goal against a fact with a call to `unify`. This may be slightly slower than tracking which indices match when comparing the tuple, though probably not by much. IMO, this is conceptually cleaner than reimplementing a buggy version of the logic already present in `unify`, and can take advantage of any future performance optimizations in `unify`.
- An attempt was made to optimize the facts under consideration by restricting to the subset of facts which match on at least one index. Then the restricted set of facts was not used. I updated the implementation to use the potentially smaller set of facts instead of always using `self.facts`.
- I added a docstring to the inner evaluated goal method, and renamed it for clarity. The docstring includes doctests with expected behavior on some simple cases.

## Testing
- I added regression tests for #33, and verified that they fail prior to 35f0504885831f61394c39ecb55a7ae978a47699 pass afterwards. 
- I verified that the `subsets` code is called by another test by looking at code coverage.
- I verified that the doctests I added do fail when the expected return values are changed to be incorrect.