### PR TITLE
More tests and minor implementation changes

### DIFF
--- a/logpy/core.py
+++ b/logpy/core.py
@@ -33,10 +33,7 @@ def eq(u, v):
 def membero(x, coll):
     """ Goal such that x is an item of coll """
     if not isvar(coll):
-        if x in coll:
-            return success
-        else:
-            return (lany,) + tuple((eq, x, item) for item in coll)
+        return (lany,) + tuple((eq, x, item) for item in coll)
     raise EarlyGoalError()
 
 ################################

--- a/logpy/core.py
+++ b/logpy/core.py
@@ -32,12 +32,11 @@ def eq(u, v):
 
 def membero(x, coll):
     """ Goal such that x is an item of coll """
-    if not isvar(x) and not isvar(coll):
+    if not isvar(coll):
         if x in coll:
             return success
-        return (lany,) + tuple((eq, x, item) for item in coll)
-    if isvar(x) and not isvar(coll):
-        return (lany,) + tuple((eq, x, item) for item in coll)
+        else:
+            return (lany,) + tuple((eq, x, item) for item in coll)
     raise EarlyGoalError()
 
 ################################

--- a/logpy/core.py
+++ b/logpy/core.py
@@ -3,7 +3,7 @@ from functools import partial
 from .util import transitive_get as walk
 from .util import deep_transitive_get as walkstar
 from .util import (dicthash, interleave, take, evalt, index, multihash, unique)
-from toolz import assoc, groupby
+from toolz import assoc, groupby, map
 
 from .variable import var, isvar
 from .unification import reify, unify
@@ -202,7 +202,7 @@ def condeseq(goalseqs):
 # User level execution #
 ########################
 
-def run(n, x, *goals, **kwargs):
+def run(n, x, *goals):
     """ Run a logic program.  Obtain n solutions to satisfy goals.
 
     n     - number of desired solutions.  See ``take``

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -136,16 +136,13 @@ typo = goalify(type)
 isinstanceo = goalify(isinstance)
 
 
-"""
--This is an attempt to create appendo.  It does not currently work.
--As written in miniKanren, appendo uses LISP machinery not present in Python
--such as quoted expressions and macros for short circuiting.  I have gotten
--around some of these issues but not all.  appendo is a stress test for this
--implementation
-"""
-
 def appendo(l, s, ls):
-    """ Byrd thesis pg. 247 """
+    """
+    Goal that ls = l + s.
+
+    See Byrd thesis pg. 247
+    https://scholarworks.iu.edu/dspace/bitstream/handle/2022/8777/Byrd_indiana_0093A_10344.pdf
+    """
     a, d, res = [var() for i in range(3)]
     return (lany, (lallgreedy, (eq, l, ()), (eq, s, ls)),
                   (lall, (conso, a, d, l), (conso, a, res, ls), (appendo, d, s, res)))

--- a/logpy/tests/test_assoccomm.py
+++ b/logpy/tests/test_assoccomm.py
@@ -1,3 +1,5 @@
+import pytest
+
 from logpy.core import var, run, goaleval
 from logpy.facts import fact
 from logpy.assoccomm import (associative, commutative,
@@ -136,15 +138,16 @@ def test_objects():
         print(reify(v, next(goaleval(eq_assoccomm(v, x))({}))))
         assert reify(v, next(goaleval(eq_assoccomm(v, x))({}))) == x
 
-"""
-Failing test.  This would work if we flattened first
+
+@pytest.mark.xfail(reason="This would work if we flattened first.",
+                   strict=True)
 def test_deep_associativity():
     expr1 = (a, 1, 2, (a, x, 5, 6))
     expr2 = (a, (a, 1, 2), 3, 4, 5, 6)
     result = ({x: (a, 3, 4)})
-    print(tuple(unify_assoc(expr1, expr2, {})))
-    assert tuple(unify_assoc(expr1, expr2, {})) == result
-"""
+    print(tuple(assocunify(expr1, expr2, {})))
+    assert tuple(assocunify(expr1, expr2, {})) == result
+
 
 def test_buildo():
     x = var('x')

--- a/logpy/tests/test_core.py
+++ b/logpy/tests/test_core.py
@@ -1,3 +1,4 @@
+import itertools
 import pytest
 from pytest import raises
 
@@ -5,7 +6,7 @@ from logpy.core import (walk, walkstar, var, run,
                         membero, evalt, fail, eq, conde,
                         goaleval, lany, lallgreedy, lanyseq,
                         goalexpand, earlyorder, EarlyGoalError, lall, earlysafe,
-                        lallfirst)
+                        lallfirst, condeseq)
 
 w, x, y, z = 'wxyz'
 
@@ -69,15 +70,14 @@ def test_conde():
     assert results(conde([eq(x, 2)], [eq(x, 3)])) == ({x: 2}, {x: 3})
     assert results(conde([eq(x, 2), eq(x, 3)])) == ()
 
-"""
 def test_condeseq():
     x = var('x')
-    assert tuple(condeseq(([eq(x, 2)], [eq(x, 3)]))({})) == ({x: 2}, {x: 3})
-    assert tuple(condeseq([[eq(x, 2), eq(x, 3)]])({})) == ()
+    assert set(run(0, x, condeseq(([eq(x, 2)], [eq(x, 3)])))) == {2, 3}
+    assert set(run(0, x, condeseq([[eq(x, 2), eq(x, 3)]]))) == set()
 
     goals = ([eq(x, i)] for i in itertools.count()) # infinite number of goals
-    assert next(condeseq(goals)({})) == {x: 0}
-"""
+    assert run(1, x, condeseq(goals)) == (0, )
+    assert run(1, x, condeseq(goals)) == (1, )
 
 def test_short_circuit():
     def badgoal(s):

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -82,11 +82,5 @@ def test_appendo():
     assert results(appendo((), (1,2), (1))) == ()
     assert results(appendo((1,2), (3,4), (1,2,3,4)))
     assert run(5, x, appendo((1,2,3), x, (1,2,3,4,5))) == ((4,5),)
-
-"""
-Failing test
-def test_appendo2():
-    print(run(5, x, appendo((1,2,3), (4,5), x)))
-    assert run(5, x, appendo(x, (4,5), (1,2,3,4,5))) == ((1,2,3),)
-    assert run(5, x, appendo((1,2,3), (4,5), x)) == ((1,2,3,4,5),)
-"""
+    assert run(5, x, appendo(x, (4, 5), (1, 2, 3, 4, 5))) == ((1, 2, 3),)
+    assert run(5, x, appendo((1, 2, 3), (4, 5), x)) == ((1, 2, 3, 4, 5),)

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -77,10 +77,19 @@ def test_conso_early():
             == (1,))
 
 def test_appendo():
-    x = var('x')
+    x, y, z, w = var('x'), var('y'), var('z'), var('w')
     assert results(appendo((), (1,2), (1,2))) == ({},)
     assert results(appendo((), (1,2), (1))) == ()
     assert results(appendo((1,2), (3,4), (1,2,3,4)))
     assert run(5, x, appendo((1,2,3), x, (1,2,3,4,5))) == ((4,5),)
     assert run(5, x, appendo(x, (4, 5), (1, 2, 3, 4, 5))) == ((1, 2, 3),)
     assert run(5, x, appendo((1, 2, 3), (4, 5), x)) == ((1, 2, 3, 4, 5),)
+
+    for t in [tuple(range(i)) for i in range(5)]:
+        for xi, yi in run(0, (x, y), appendo(x, y, t)):
+            assert xi + yi == t
+
+        for xi, yi, zi in run(0, (x, y, z),
+                              appendo(x, y, w),
+                              appendo(w, z, t)):
+            assert xi + yi + zi == t

--- a/logpy/tests/test_util.py
+++ b/logpy/tests/test_util.py
@@ -1,6 +1,5 @@
 from logpy.util import (take, unique, interleave, intersection,
         groupsizes, dicthash, hashable, multihash)
-import itertools
 
 def test_hashable():
     assert hashable(2)


### PR DESCRIPTION
This PR:
- Uncomments some tests, many of which passed with a few fixes. The one that didn't is marked as an expected failure using pytest's system for doing that.
- Simplified the implementation of `membero` a bit.
- Corrected the comment that `appendo` is incomplete. I added some tests for it, and AFAICT, its implementation is functioning correctly.
- Fixed a bug in `condeseq` in python 2.7, where it used the builtin `map`. This means that it never might never complete when given an infinite sequence of goals.

I'll merge tomorrow if there are no objections / comments.