### PR TITLE
Add linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ python:
     - "pypy"
     - "pypy3"
 install:
-    - pip install coverage toolz multipledispatch pytest pytest-cov
+    - pip install coverage toolz multipledispatch pytest pytest-cov flake8
 script:
     - py.test --cov=logpy -vv logpy
+    - flake8 logpy
 after_success:
     - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then
         pip install coveralls --use-mirrors;

--- a/logpy/__init__.py
+++ b/logpy/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 LogPy is a Python library for logic and relational programming.
 """

--- a/logpy/arith.py
+++ b/logpy/arith.py
@@ -1,4 +1,6 @@
-from logpy.core import (isvar, var, run, membero, eq, EarlyGoalError, lany)
+import operator
+
+from logpy.core import (isvar, eq, EarlyGoalError, lany)
 
 
 def gt(x, y):
@@ -32,8 +34,6 @@ def lor(*goalconsts):
 
 gte = lor(gt, eq)
 lte = lor(lt, eq)
-
-import operator
 
 
 def binop(op, revop=None):

--- a/logpy/arith.py
+++ b/logpy/arith.py
@@ -1,11 +1,13 @@
 from logpy.core import (isvar, var, run, membero, eq, EarlyGoalError, lany)
 
+
 def gt(x, y):
     """ x > y """
     if not isvar(x) and not isvar(y):
         return eq(x > y, True)
     else:
         raise EarlyGoalError()
+
 
 def lt(x, y):
     """ x > y """
@@ -14,20 +16,25 @@ def lt(x, y):
     else:
         raise EarlyGoalError()
 
+
 def lor(*goalconsts):
     """ Logical or for goal constructors
 
     >>> from logpy.arith import lor, eq, gt
     >>> gte = lor(eq, gt)  # greater than or equal to is `eq or gt`
     """
+
     def goal(*args):
         return lany(*[gc(*args) for gc in goalconsts])
+
     return goal
+
 
 gte = lor(gt, eq)
 lte = lor(lt, eq)
 
 import operator
+
 
 def binop(op, revop=None):
     """ Transform binary operator into goal
@@ -50,8 +57,10 @@ def binop(op, revop=None):
         if not isvar(x) and not isvar(z) and revop:
             return eq(y, revop(z, x))
         raise EarlyGoalError()
+
     goal.__name__ = op.__name__
     return goal
+
 
 add = binop(operator.add, operator.sub)
 add.__doc__ = """ x + y == z """
@@ -60,9 +69,11 @@ mul.__doc__ = """ x * y == z """
 mod = binop(operator.mod)
 mod.__doc__ = """ x % y == z """
 
+
 def sub(x, y, z):
     """ x - y == z """
     return add(y, z, x)
+
 
 def div(x, y, z):
     """ x / y == z """

--- a/logpy/assoccomm.py
+++ b/logpy/assoccomm.py
@@ -29,9 +29,8 @@ be used in the computer algebra systems SymPy and Theano.
 ((3, 2),)
 """
 
-from logpy.core import (isvar, assoc, unify,
-                        conde, var, eq, fail, goaleval, lallgreedy, EarlyGoalError,
-                        condeseq, goaleval)
+from logpy.core import (isvar, assoc, unify, conde, var, eq, fail, goaleval,
+                        lallgreedy, EarlyGoalError, condeseq, goaleval)
 from .goals import heado, permuteq, conso, tailo
 from .facts import Relation
 from logpy import core
@@ -39,9 +38,9 @@ from .util import groupsizes, index
 from .util import transitive_get as walk
 from .term import term, arguments, operator
 
-
 associative = Relation('associative')
 commutative = Relation('commutative')
+
 
 def assocunify(u, v, s, eq=core.eq, n=None):
     """ Associative Unification
@@ -55,7 +54,7 @@ def assocunify(u, v, s, eq=core.eq, n=None):
     if not uop and not vop:
         res = unify(u, v, s)
         if res is not False:
-            return (res,)  # TODO: iterate through all possibilities
+            return (res, )  # TODO: iterate through all possibilities
 
     if uop and vop:
         s = unify(uop, vop, s)
@@ -75,17 +74,19 @@ def assocunify(u, v, s, eq=core.eq, n=None):
         op, tail = vop, vargs
         b = u
 
-    ns = [n] if n else range(2, len(tail)+1)
+    ns = [n] if n else range(2, len(tail) + 1)
     knowns = (build(op, x) for n in ns for x in assocsized(op, tail, n))
 
     goal = condeseq([(core.eq, b, k)] for k in knowns)
     return goaleval(goal)(s)
+
 
 def assocsized(op, tail, n):
     """ All associative combinations of x in n groups """
     gsizess = groupsizes(len(tail), n)
     partitions = (groupsizes_to_partition(*gsizes) for gsizes in gsizess)
     return (makeops(op, partition(tail, part)) for part in partitions)
+
 
 def makeops(op, lists):
     """ Construct operations from an op and parition lists
@@ -96,6 +97,7 @@ def makeops(op, lists):
     """
     return tuple(l[0] if len(l) == 1 else build(op, l) for l in lists)
 
+
 def partition(tup, part):
     """ Partition a tuple
 
@@ -104,6 +106,7 @@ def partition(tup, part):
     [('a', 'b'), ('e', 'd', 'c')]
     """
     return [index(tup, ind) for ind in part]
+
 
 def groupsizes_to_partition(*gsizes):
     """
@@ -121,6 +124,7 @@ def groupsizes_to_partition(*gsizes):
         part.append(l)
     return part
 
+
 def eq_assoc(u, v, eq=core.eq, n=None):
     """ Goal for associative equality
 
@@ -137,18 +141,16 @@ def eq_assoc(u, v, eq=core.eq, n=None):
     uop, _ = op_args(u)
     vop, _ = op_args(v)
     if uop and vop:
-        return conde([(core.eq, u, v)],
-                     [(eq, uop, vop), (associative, uop),
-                      lambda s: assocunify(u, v, s, eq, n)])
+        return conde([(core.eq, u, v)], [(eq, uop, vop), (associative, uop),
+                                         lambda s: assocunify(u, v, s, eq, n)])
 
     if uop or vop:
 
         if vop:
             uop, vop = vop, uop
             v, u = u, v
-        return conde([(core.eq, u, v)],
-                     [(associative, uop),
-                      lambda s: assocunify(u, v, s, eq, n)])
+        return conde([(core.eq, u, v)], [(associative, uop),
+                                         lambda s: assocunify(u, v, s, eq, n)])
 
     return (core.eq, u, v)
 
@@ -178,10 +180,10 @@ def eq_comm(u, v, eq=None):
     if vop and not uop:
         uop, uargs = vop, vargs
         v, u = u, v
-    return (conde, ((core.eq, u, v),),
-                   ((commutative, uop),
-                    (buildo, uop, vtail, v),
-                    (permuteq, uargs, vtail, eq)))
+    return (conde, ((core.eq, u, v), ),
+            ((commutative, uop), (buildo, uop, vtail, v),
+             (permuteq, uargs, vtail, eq)))
+
 
 def buildo(op, args, obj):
     """ obj is composed of op on args
@@ -201,6 +203,7 @@ def buildo(op, args, obj):
             raise EarlyGoalError()
     raise EarlyGoalError()
 
+
 def build(op, args):
     try:
         return term(op, args)
@@ -216,6 +219,7 @@ def op_args(x):
         return operator(x), arguments(x)
     except NotImplementedError:
         return None, None
+
 
 def eq_assoccomm(u, v):
     """ Associative/Commutative eq
@@ -249,9 +253,9 @@ def eq_assoccomm(u, v):
         return fail
     if uop and vop and uop != vop:
         return fail
-    if uop and not (uop,) in associative.facts:
+    if uop and not (uop, ) in associative.facts:
         return (eq, u, v)
-    if vop and not (vop,) in associative.facts:
+    if vop and not (vop, ) in associative.facts:
         return (eq, u, v)
 
     if uop and vop:

--- a/logpy/assoccomm.py
+++ b/logpy/assoccomm.py
@@ -29,9 +29,9 @@ be used in the computer algebra systems SymPy and Theano.
 ((3, 2),)
 """
 
-from logpy.core import (isvar, assoc, unify, conde, var, eq, fail, goaleval,
+from logpy.core import (isvar, unify, conde, var, eq, fail,
                         lallgreedy, EarlyGoalError, condeseq, goaleval)
-from .goals import heado, permuteq, conso, tailo
+from .goals import permuteq
 from .facts import Relation
 from logpy import core
 from .util import groupsizes, index

--- a/logpy/assoccomm.py
+++ b/logpy/assoccomm.py
@@ -29,8 +29,8 @@ be used in the computer algebra systems SymPy and Theano.
 ((3, 2),)
 """
 
-from logpy.core import (isvar, unify, conde, var, eq, fail,
-                        lallgreedy, EarlyGoalError, condeseq, goaleval)
+from logpy.core import (isvar, unify, conde, var, eq, fail, lallgreedy,
+                        EarlyGoalError, condeseq, goaleval)
 from .goals import permuteq
 from .facts import Relation
 from logpy import core

--- a/logpy/core.py
+++ b/logpy/core.py
@@ -1,11 +1,10 @@
 import itertools as it
 from functools import partial
-from .util import transitive_get as walk
-from .util import deep_transitive_get as walkstar
-from .util import (dicthash, interleave, take, evalt, index, multihash, unique)
-from toolz import assoc, groupby, map
+from .util import (dicthash, interleave, take, multihash, unique)
+from toolz import groupby, map
 
-from .variable import var, isvar
+from .variable import var  # noqa
+from .variable import isvar
 from .unification import reify, unify
 
 #########
@@ -73,7 +72,7 @@ def lallgreedy(*goals):
     >>> x, y = var('x'), var('y')
     >>> run(0, x, lallgreedy((eq, y, set([1]))), (membero, x, y))
     (1,)
-    >>> run(0, x, lallgreedy((membero, x, y), (eq, y, set([1]))))  # doctest: +SKIP
+    >>> run(0, x, lallgreedy((membero, x, y), (eq, y, {1})))  # doctest: +SKIP
     Traceback (most recent call last):
       ...
     logpy.core.EarlyGoalError
@@ -215,7 +214,9 @@ def lanyseq(goals):
 
 
 def condeseq(goalseqs):
-    """ Like conde but supports generic (possibly infinite) iterator of goals"""
+    """
+    Like conde but supports generic (possibly infinite) iterator of goals
+    """
     return (lanyseq, ((lall, ) + tuple(gs) for gs in goalseqs))
 
 ########################

--- a/logpy/core.py
+++ b/logpy/core.py
@@ -8,15 +8,18 @@ from toolz import assoc, groupby, map
 from .variable import var, isvar
 from .unification import reify, unify
 
-
 #########
 # Goals #
 #########
 
+
 def fail(s):
     return ()
+
+
 def success(s):
-    return (s,)
+    return (s, )
+
 
 def eq(u, v):
     """ Goal such that u == v
@@ -24,21 +27,25 @@ def eq(u, v):
     See also:
         unify
     """
+
     def goal_eq(s):
         result = unify(u, v, s)
         if result is not False:
             yield result
+
     return goal_eq
+
 
 def membero(x, coll):
     """ Goal such that x is an item of coll """
     if not isvar(coll):
-        return (lany,) + tuple((eq, x, item) for item in coll)
+        return (lany, ) + tuple((eq, x, item) for item in coll)
     raise EarlyGoalError()
 
 ################################
 # Logical combination of goals #
 ################################
+
 
 def lall(*goals):
     """ Logical all with goal reordering to avoid EarlyGoalErrors
@@ -52,7 +59,8 @@ def lall(*goals):
     >>> run(0, x, lall(membero(x, (1,2,3)), membero(x, (2,3,4))))
     (2, 3)
     """
-    return (lallgreedy,) + tuple(earlyorder(*goals))
+    return (lallgreedy, ) + tuple(earlyorder(*goals))
+
 
 def lallgreedy(*goals):
     """ Logical all that greedily evaluates each goals in the order provided.
@@ -74,13 +82,16 @@ def lallgreedy(*goals):
         return success
     if len(goals) == 1:
         return goals[0]
+
     def allgoal(s):
         g = goaleval(reify(goals[0], s))
-        return unique(interleave(
-                        goaleval(reify((lallgreedy,) + tuple(goals[1:]), ss))(ss)
-                        for ss in g(s)),
-                      key=dicthash)
+        return unique(
+            interleave(goaleval(reify(
+                (lallgreedy, ) + tuple(goals[1:]), ss))(ss) for ss in g(s)),
+            key=dicthash)
+
     return allgoal
+
 
 def lallfirst(*goals):
     """ Logical all - Run goals one at a time
@@ -97,19 +108,23 @@ def lallfirst(*goals):
         return success
     if len(goals) == 1:
         return goals[0]
+
     def allgoal(s):
         for i, g in enumerate(goals):
             try:
                 goal = goaleval(reify(g, s))
             except EarlyGoalError:
                 continue
-            other_goals = tuple(goals[:i] + goals[i+1:])
-            return unique(interleave(goaleval(
-                reify((lallfirst,) + other_goals, ss))(ss)
-                for ss in goal(s)), key=dicthash)
+            other_goals = tuple(goals[:i] + goals[i + 1:])
+            return unique(
+                interleave(goaleval(reify(
+                    (lallfirst, ) + other_goals, ss))(ss) for ss in goal(s)),
+                key=dicthash)
         else:
             raise EarlyGoalError()
+
     return allgoal
+
 
 def lany(*goals):
     """ Logical any
@@ -124,6 +139,7 @@ def lany(*goals):
         return goals[0]
     return lanyseq(goals)
 
+
 def earlysafe(goal):
     """ Call goal be evaluated without raising an EarlyGoalError """
     try:
@@ -131,6 +147,7 @@ def earlysafe(goal):
         return True
     except EarlyGoalError:
         return False
+
 
 def earlyorder(*goals):
     """ Reorder goals to avoid EarlyGoalErrors
@@ -145,14 +162,15 @@ def earlyorder(*goals):
         return ()
     groups = groupby(earlysafe, goals)
     good = groups.get(True, [])
-    bad  = groups.get(False, [])
+    bad = groups.get(False, [])
 
     if not good:
         raise EarlyGoalError()
     elif not bad:
         return tuple(good)
     else:
-        return tuple(good) + ((lall,) + tuple(bad),)
+        return tuple(good) + ((lall, ) + tuple(bad), )
+
 
 def conde(*goalseqs):
     """ Logical cond
@@ -166,7 +184,7 @@ def conde(*goalseqs):
         lall - logical all
         lany - logical any
     """
-    return (lany, ) + tuple((lall,) + tuple(gs) for gs in goalseqs)
+    return (lany, ) + tuple((lall, ) + tuple(gs) for gs in goalseqs)
 
 
 def lanyseq(goals):
@@ -175,8 +193,10 @@ def lanyseq(goals):
     Note:  If using lanyseq with a generator you must call lanyseq, not include
     it in a tuple
     """
+
     def anygoal(s):
         anygoal.goals, local_goals = it.tee(anygoal.goals)
+
         def f(goals):
             for goal in goals:
                 try:
@@ -184,19 +204,24 @@ def lanyseq(goals):
                 except EarlyGoalError:
                     pass
 
-        return unique(interleave(f(local_goals), [EarlyGoalError]),
-                      key=dicthash)
+        return unique(
+            interleave(
+                f(local_goals), [EarlyGoalError]),
+            key=dicthash)
+
     anygoal.goals = goals
 
     return anygoal
 
+
 def condeseq(goalseqs):
     """ Like conde but supports generic (possibly infinite) iterator of goals"""
-    return (lanyseq, ((lall,) + tuple(gs) for gs in goalseqs))
+    return (lanyseq, ((lall, ) + tuple(gs) for gs in goalseqs))
 
 ########################
 # User level execution #
 ########################
+
 
 def run(n, x, *goals):
     """ Run a logic program.  Obtain n solutions to satisfy goals.
@@ -218,6 +243,7 @@ def run(n, x, *goals):
 ###################
 # Goal Evaluation #
 ###################
+
 
 class EarlyGoalError(Exception):
     """ A Goal has been constructed prematurely
@@ -245,6 +271,7 @@ class EarlyGoalError(Exception):
         earlyorder
     """
 
+
 def goalexpand(goalt):
     """ Expand a goal tuple until it can no longer be expanded
 
@@ -270,9 +297,9 @@ def goaleval(goal):
     See also:
        goalexpand
     """
-    if callable(goal):          # goal is already a function like eq(x, 1)
+    if callable(goal):  # goal is already a function like eq(x, 1)
         return goal
-    if isinstance(goal, tuple): # goal is not yet evaluated like (eq, x, 1)
+    if isinstance(goal, tuple):  # goal is not yet evaluated like (eq, x, 1)
         egoal = goalexpand(goal)
         # from logpy.util import pprint
         # print(pprint(egoal))

--- a/logpy/facts.py
+++ b/logpy/facts.py
@@ -6,11 +6,12 @@ from toolz import merge
 
 class Relation(object):
     _id = 0
+
     def __init__(self, name=None):
         self.facts = set()
         self.index = dict()
         if not name:
-            name = "_%d"%Relation._id
+            name = "_%d" % Relation._id
             Relation._id += 1
         self.name = name
 
@@ -51,11 +52,12 @@ class Relation(object):
         >>> list(r(x, 42, y)({}))
         []
         """
+
         def goal(substitution):
             args2 = reify(args, substitution)
             subsets = [self.index[key] for key in enumerate(args)
-                                       if  key in self.index]
-            if subsets:     # we are able to reduce the pool early
+                       if key in self.index]
+            if subsets:  # we are able to reduce the pool early
                 facts = intersection(*sorted(subsets, key=len))
             else:
                 facts = self.facts
@@ -69,6 +71,7 @@ class Relation(object):
 
     def __str__(self):
         return "Rel: " + self.name
+
     __repr__ = __str__
 
 
@@ -86,6 +89,7 @@ def fact(rel, *args):
     """
     rel.add_fact(*args)
 
+
 def facts(rel, *lists):
     """ Declare several facts
 
@@ -100,4 +104,3 @@ def facts(rel, *lists):
     """
     for l in lists:
         fact(rel, *l)
-

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -1,5 +1,5 @@
-from .core import (eq, EarlyGoalError, conde, condeseq, lany,
-                   lallgreedy, lall, fail, success)
+from .core import (eq, EarlyGoalError, conde, condeseq, lany, lallgreedy, lall,
+                   fail, success)
 from .util import unique
 from .variable import var, isvar
 import itertools as it

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -1,7 +1,8 @@
-from .core import (var, isvar, eq, EarlyGoalError, conde, condeseq, lany, lallgreedy,
-                   lall, fail, success)
+from .core import (var, isvar, eq, EarlyGoalError, conde, condeseq, lany,
+                   lallgreedy, lall, fail, success)
 from .util import unique
 import itertools as it
+
 
 def heado(x, coll):
     """ x is the head of coll
@@ -17,6 +18,7 @@ def heado(x, coll):
     else:
         return fail
 
+
 def tailo(x, coll):
     """ x is the tail of coll
 
@@ -31,6 +33,7 @@ def tailo(x, coll):
     else:
         return fail
 
+
 def conso(h, t, l):
     """ Logical cons -- l[0], l[1:] == h, t """
     if isinstance(l, tuple):
@@ -39,9 +42,10 @@ def conso(h, t, l):
         else:
             return (conde, [(eq, h, l[0]), (eq, t, l[1:])])
     elif isinstance(t, tuple):
-        return eq((h,) + t, l)
+        return eq((h, ) + t, l)
     else:
         raise EarlyGoalError()
+
 
 def permuteq(a, b, eq2=eq):
     """ Equality under permutation
@@ -68,9 +72,8 @@ def permuteq(a, b, eq2=eq):
                 pass
             if len(c) == 1:
                 return (eq2, c[0], d[0])
-            return condeseq((
-                   ((eq2, c[i], d[0]), (permuteq, c[0:i] + c[i+1:], d[1:], eq2))
-                        for i in range(len(c))))
+            return condeseq((((eq2, c[i], d[0]), (permuteq, c[0:i] + c[
+                i + 1:], d[1:], eq2)) for i in range(len(c))))
 
     if isvar(a) and isvar(b):
         raise EarlyGoalError()
@@ -83,6 +86,7 @@ def permuteq(a, b, eq2=eq):
 
         return (condeseq, ([eq(c, perm)]
                            for perm in unique(it.permutations(d, len(d)))))
+
 
 def seteq(a, b, eq2=eq):
     """ Set Equality
@@ -122,6 +126,7 @@ def goalify(func):
     >>> print([result.__name__ for result in results])
     ['int', 'str']
     """
+
     def funco(inputs, out):
         if isvar(inputs):
             raise EarlyGoalError()
@@ -130,7 +135,9 @@ def goalify(func):
                 return (eq, func(*inputs), out)
             else:
                 return (eq, func(inputs), out)
+
     return funco
+
 
 typo = goalify(type)
 isinstanceo = goalify(isinstance)
@@ -145,4 +152,5 @@ def appendo(l, s, ls):
     """
     a, d, res = [var() for i in range(3)]
     return (lany, (lallgreedy, (eq, l, ()), (eq, s, ls)),
-                  (lall, (conso, a, d, l), (conso, a, res, ls), (appendo, d, s, res)))
+            (lall, (conso, a, d, l), (conso, a, res, ls),
+             (appendo, d, s, res)))

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -1,6 +1,7 @@
-from .core import (var, isvar, eq, EarlyGoalError, conde, condeseq, lany,
+from .core import (eq, EarlyGoalError, conde, condeseq, lany,
                    lallgreedy, lall, fail, success)
 from .util import unique
+from .variable import var, isvar
 import itertools as it
 
 

--- a/logpy/term.py
+++ b/logpy/term.py
@@ -14,7 +14,7 @@ def operator(seq):
 
 @dispatch(object, (tuple, list))
 def term(op, args):
-    return (op,) + tuple(args)
+    return (op, ) + tuple(args)
 
 
 def unifiable_with_term(cls):

--- a/logpy/tests/test_arith.py
+++ b/logpy/tests/test_arith.py
@@ -3,24 +3,31 @@ from logpy.arith import lt, gt, lte, gte, add, sub, mul, mod, div
 
 x = var('x')
 y = var('y')
+
+
 def results(g):
     return list(g({}))
+
 
 def test_lt():
     assert results(lt(1, 2))
     assert not results(lt(2, 1))
     assert not results(lt(2, 2))
 
+
 def test_gt():
     assert results(gt(2, 1))
     assert not results(gt(1, 2))
     assert not results(gt(2, 2))
 
+
 def test_lte():
     assert results(lte(2, 2))
 
+
 def test_gte():
     assert results(gte(2, 2))
+
 
 def test_add():
     assert results(add(1, 2, 3))
@@ -31,6 +38,7 @@ def test_add():
     assert results(add(1, x, 3)) == [{x: 2}]
     assert results(add(x, 2, 3)) == [{x: 1}]
 
+
 def test_sub():
     assert results(sub(3, 2, 1))
     assert not results(sub(4, 2, 1))
@@ -38,6 +46,7 @@ def test_sub():
     assert results(sub(3, 2, x)) == [{x: 1}]
     assert results(sub(3, x, 1)) == [{x: 2}]
     assert results(sub(x, 2, 1)) == [{x: 3}]
+
 
 def test_mul():
     assert results(mul(2, 3, 6))
@@ -49,21 +58,22 @@ def test_mul():
 
     assert mul.__name__ == 'mul'
 
+
 def test_mod():
     assert results(mod(5, 3, 2))
+
 
 def test_div():
     assert results(div(6, 2, 3))
     assert not results(div(6, 2, 2))
     assert results(div(6, 2, x)) == [{x: 3}]
 
+
 def test_complex():
     from logpy import run, membero
     numbers = tuple(range(10))
-    results = set(run(0, x, (sub, y, x, 1),
-                            (membero, y, numbers),
-                            (mod, y, 2, 0),
-                            (membero, x, numbers)))
+    results = set(run(0, x, (sub, y, x, 1), (membero, y, numbers), (
+        mod, y, 2, 0), (membero, x, numbers)))
     expected = set((1, 3, 5, 7))
     print(results)
     assert results == expected

--- a/logpy/tests/test_assoccomm.py
+++ b/logpy/tests/test_assoccomm.py
@@ -103,7 +103,7 @@ def test_assocunify():
     assert tuple(assocunify((a, 1, (a, 2, 3)), (a, 1, 2, 3), {}))
     assert tuple(assocunify((a, 1, (a, 2, 3), 4), (a, 1, 2, 3, 4), {}))
     assert tuple(assocunify((a, 1, x, 4), (a, 1, 2, 3, 4), {})) == \
-                ({x: (a, 2, 3)},)
+                ({x: (a, 2, 3)}, )
     assert tuple(assocunify((a, 1, 1), ('other_op', 1, 1), {})) == ()
 
     assert tuple(assocunify((a, 1, 1), (x, 1, 1), {})) == ({x: a}, )
@@ -126,7 +126,7 @@ def test_assocsized():
     assert set(assocsized(add, (1, 2, 3), 2)) == \
             set((((add, 1, 2), 3), (1, (add, 2, 3))))
     assert set(assocsized(add, (1, 2, 3), 1)) == \
-            set((((add, 1, 2, 3),),))
+            set((((add, 1, 2, 3), ), ))
 
 
 def test_objects():
@@ -226,13 +226,13 @@ def test_op_args():
 
 def test_buildo_object():
     x = var('x')
-    assert results(buildo(Add, (1,2,3), x), {}) == \
-            ({x: add(1, 2, 3)},)
+    assert results(buildo(Add, (1, 2, 3), x), {}) == \
+            ({x: add(1, 2, 3)}, )
     print(results(buildo(x, (1, 2, 3), add(1, 2, 3)), {}))
-    assert results(buildo(x, (1,2,3), add(1,2,3)), {}) == \
-            ({x: Add},)
-    assert results(buildo(Add, x, add(1,2,3)), {}) == \
-            ({x: (1,2,3)},)
+    assert results(buildo(x, (1, 2, 3), add(1, 2, 3)), {}) == \
+            ({x: Add}, )
+    assert results(buildo(Add, x, add(1, 2, 3)), {}) == \
+            ({x: (1, 2, 3)}, )
 
 
 def test_eq_comm_object():

--- a/logpy/tests/test_assoccomm.py
+++ b/logpy/tests/test_assoccomm.py
@@ -2,9 +2,9 @@ import pytest
 
 from logpy.core import var, run, goaleval
 from logpy.facts import fact
-from logpy.assoccomm import (associative, commutative,
-        groupsizes_to_partition, assocunify, eq_comm, eq_assoc,
-        eq_assoccomm, assocsized, buildo, op_args)
+from logpy.assoccomm import (associative, commutative, groupsizes_to_partition,
+                             assocunify, eq_comm, eq_assoc, eq_assoccomm,
+                             assocsized, buildo, op_args)
 from logpy.dispatch import dispatch
 
 a = 'assoc_op'
@@ -13,19 +13,21 @@ x, y = var('x'), var('y')
 fact(associative, a)
 fact(commutative, c)
 
+
 def results(g, s={}):
     return tuple(goaleval(g)(s))
+
 
 def test_eq_comm():
     assert results(eq_comm(1, 1))
     assert results(eq_comm((c, 1, 2, 3), (c, 1, 2, 3)))
     assert results(eq_comm((c, 3, 2, 1), (c, 1, 2, 3)))
-    assert not results(eq_comm((a, 3, 2, 1), (a, 1, 2, 3))) # not commutative
+    assert not results(eq_comm((a, 3, 2, 1), (a, 1, 2, 3)))  # not commutative
     assert not results(eq_comm((3, c, 2, 1), (c, 1, 2, 3)))
     assert not results(eq_comm((c, 1, 2, 1), (c, 1, 2, 3)))
     assert not results(eq_comm((a, 1, 2, 3), (c, 1, 2, 3)))
     assert len(results(eq_comm((c, 3, 2, 1), x))) >= 6
-    assert results(eq_comm(x, y)) == ({x: y},)
+    assert results(eq_comm(x, y)) == ({x: y}, )
 
 
 def test_eq_assoc():
@@ -39,10 +41,13 @@ def test_eq_assoc():
 
     # See TODO in assocunify
     gen = results(eq_assoc((a, 1, 2, 3), x, n=2))
-    assert set(g[x] for g in gen).issuperset(set([(a,(a,1,2),3), (a,1,(a,2,3))]))
+    assert set(
+        g[x]
+        for g in gen).issuperset(set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))]))
     gen = results(eq_assoc(x, (a, 1, 2, 3), n=2))
-    assert set(g[x] for g in gen).issuperset(
-        set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))]))
+    assert set(
+        g[x]
+        for g in gen).issuperset(set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))]))
 
 
 def test_eq_assoccomm():
@@ -52,16 +57,17 @@ def test_eq_assoccomm():
     fact(commutative, ac)
     fact(associative, ac)
     assert results(eqac(1, 1))
-    assert results(eqac((1,), (1,)))
-    assert results(eqac(x, (1,)))
-    assert results(eqac((1,), x))
+    assert results(eqac((1, ), (1, )))
+    assert results(eqac(x, (1, )))
+    assert results(eqac((1, ), x))
     assert results(eqac((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1))))
     assert results((eqac, 1, 1))
     assert results(eqac((a, (a, 1, 2), 3), (a, 1, 2, 3)))
     assert results(eqac((ac, (ac, 1, 2), 3), (ac, 1, 2, 3)))
     assert results(eqac((ac, 3, (ac, 1, 2)), (ac, 1, 2, 3)))
     assert not results(eqac((ac, 1, 1), ('other_op', 1, 1)))
-    assert run(0, x, eqac((ac, 3, (ac, 1, 2)), (ac, 1, x, 3))) == (2,)
+    assert run(0, x, eqac((ac, 3, (ac, 1, 2)), (ac, 1, x, 3))) == (2, )
+
 
 def test_expr():
     add = 'add'
@@ -73,19 +79,22 @@ def test_expr():
 
     x, y = var('x'), var('y')
 
-    pattern = (mul, (add, 1, x), y)                # (1 + x) * y
-    expr    = (mul, 2, (add, 3, 1))                # 2 * (3 + 1)
-    assert run(0, (x,y), eq_assoccomm(pattern, expr)) == ((3, 2),)
+    pattern = (mul, (add, 1, x), y)  # (1 + x) * y
+    expr = (mul, 2, (add, 3, 1))  # 2 * (3 + 1)
+    assert run(0, (x, y), eq_assoccomm(pattern, expr)) == ((3, 2), )
+
 
 def test_deep_commutativity():
     x, y = var('x'), var('y')
 
     e1 = (c, (c, 1, x), y)
     e2 = (c, 2, (c, 3, 1))
-    assert run(0, (x,y), eq_comm(e1, e2)) == ((3, 2),)
+    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2), )
+
 
 def test_groupsizes_to_parition():
     assert groupsizes_to_partition(2, 3) == [[0, 1], [2, 3, 4]]
+
 
 def test_assocunify():
     assert tuple(assocunify(1, 1, {}))
@@ -101,12 +110,16 @@ def test_assocunify():
     assert tuple(assocunify((x, 1, 1), (a, 1, 1), {})) == ({x: a}, )
 
     gen = assocunify((a, 1, 2, 3), x, {}, n=2)
-    assert set(g[x] for g in gen) == set([(a,(a,1,2),3), (a,1,(a,2,3))])
+    assert set(g[x]
+               for g in gen) == set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
     gen = assocunify(x, (a, 1, 2, 3), {}, n=2)
-    assert set(g[x] for g in gen) == set([(a,(a,1,2),3), (a,1,(a,2,3))])
+    assert set(g[x]
+               for g in gen) == set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
 
     gen = assocunify((a, 1, 2, 3), x, {})
-    assert set(g[x] for g in gen) == set([(a,1,2,3), (a,(a,1,2),3), (a,1,(a,2,3))])
+    assert set(g[x] for g in gen) == set([(a, 1, 2, 3), (a, (a, 1, 2), 3), (
+        a, 1, (a, 2, 3))])
+
 
 def test_assocsized():
     add = 'add'
@@ -114,6 +127,7 @@ def test_assocsized():
             set((((add, 1, 2), 3), (1, (add, 2, 3))))
     assert set(assocsized(add, (1, 2, 3), 1)) == \
             set((((add, 1, 2, 3),),))
+
 
 def test_objects():
     from logpy import variables, reify
@@ -126,13 +140,13 @@ def test_objects():
     x = var('x')
 
     print(tuple(goaleval(eq_assoccomm(add(1, 2, 3), add(1, 2, x)))({})))
-    assert reify(x, tuple(goaleval(eq_assoccomm(add(1, 2, 3),
-                                                add(1, 2, x)))({}))[0]) == 3
+    assert reify(x, tuple(goaleval(eq_assoccomm(
+        add(1, 2, 3), add(1, 2, x)))({}))[0]) == 3
 
-    assert reify(x, next(goaleval(eq_assoccomm(add(1, 2, 3),
-                                               add(x, 2, 1)))({}))) == 3
+    assert reify(x, next(goaleval(eq_assoccomm(
+        add(1, 2, 3), add(x, 2, 1)))({}))) == 3
 
-    v = add(1,2,3)
+    v = add(1, 2, 3)
     with variables(v):
         x = add(5, 6)
         print(reify(v, next(goaleval(eq_assoccomm(v, x))({}))))
@@ -151,40 +165,53 @@ def test_deep_associativity():
 
 def test_buildo():
     x = var('x')
-    assert results(buildo('add', (1,2,3), x), {}) == ({x: ('add', 1, 2, 3)},)
-    assert results(buildo(x, (1,2,3), ('add', 1,2,3)), {}) == ({x: 'add'},)
-    assert results(buildo('add', x, ('add', 1,2,3)), {}) == ({x: (1,2,3)},)
+    assert results(
+        buildo('add', (1, 2, 3), x), {}) == ({x: ('add', 1, 2, 3)}, )
+    assert results(
+        buildo(x, (1, 2, 3), ('add', 1, 2, 3)), {}) == ({x: 'add'}, )
+    assert results(
+        buildo('add', x, ('add', 1, 2, 3)), {}) == ({x: (1, 2, 3)}, )
+
 
 class Node(object):
     def __init__(self, op, args):
         self.op = op
         self.args = args
+
     def __eq__(self, other):
-        return (type(self) == type(other)
-                and self.op == other.op
-                and self.args == other.args)
+        return (type(self) == type(other) and self.op == other.op and
+                self.args == other.args)
+
     def __hash__(self):
         return hash((type(self), self.op, self.args))
+
     def __str__(self):
         return '%s(%s)' % (self.op.name, ', '.join(map(str, self.args)))
+
     __repr__ = __str__
+
 
 class Operator(object):
     def __init__(self, name):
         self.name = name
+
+
 Add = Operator('add')
 Mul = Operator('mul')
 
 add = lambda *args: Node(Add, args)
 mul = lambda *args: Node(Mul, args)
 
+
 @dispatch(Operator, (tuple, list))
 def term(op, args):
     return Node(op, args)
 
+
 @dispatch(Node)
 def arguments(n):
     return n.args
+
 
 @dispatch(Node)
 def operator(n):
@@ -192,15 +219,16 @@ def operator(n):
 
 
 def test_op_args():
-    print(op_args(add(1,2,3)))
-    assert op_args(add(1,2,3)) == (Add, (1,2,3))
+    print(op_args(add(1, 2, 3)))
+    assert op_args(add(1, 2, 3)) == (Add, (1, 2, 3))
     assert op_args('foo') == (None, None)
+
 
 def test_buildo_object():
     x = var('x')
     assert results(buildo(Add, (1,2,3), x), {}) == \
             ({x: add(1, 2, 3)},)
-    print(results(buildo(x, (1,2,3), add(1,2,3)), {}))
+    print(results(buildo(x, (1, 2, 3), add(1, 2, 3)), {}))
     assert results(buildo(x, (1,2,3), add(1,2,3)), {}) == \
             ({x: Add},)
     assert results(buildo(Add, x, add(1,2,3)), {}) == \
@@ -212,7 +240,7 @@ def test_eq_comm_object():
     fact(commutative, Add)
     fact(associative, Add)
 
-    assert run(0, x, eq_comm(add(1, 2, 3), add(3, 1, x))) == (2,)
+    assert run(0, x, eq_comm(add(1, 2, 3), add(3, 1, x))) == (2, )
 
     print(set(run(0, x, eq_comm(add(1, 2), x))))
     assert set(run(0, x, eq_comm(add(1, 2), x))) == set((add(1, 2), add(2, 1)))

--- a/logpy/tests/test_core.py
+++ b/logpy/tests/test_core.py
@@ -2,10 +2,14 @@ import itertools
 import pytest
 from pytest import raises
 
-from logpy.core import (walk, walkstar, var, run, membero, evalt, fail, eq,
+from logpy.core import (run, membero, fail, eq,
                         conde, goaleval, lany, lallgreedy, lanyseq, goalexpand,
                         earlyorder, EarlyGoalError, lall, earlysafe, lallfirst,
                         condeseq)
+from logpy.util import transitive_get as walk
+from logpy.util import deep_transitive_get as walkstar
+from logpy.util import evalt
+from logpy.variable import var
 
 w, x, y, z = 'wxyz'
 
@@ -144,8 +148,10 @@ def test_evalt():
 
 def test_uneval_membero():
     x, y = var('x'), var('y')
-    assert set(run(100, x, (membero, y, ((1,2,3),(4,5,6))), (membero, x, y))) == \
-           set((1,2,3,4,5,6))
+    assert set(run(100, x, (membero, y,
+                            ((1, 2, 3), (4, 5, 6))),
+                            (membero, x, y))) == \
+           set((1, 2, 3, 4, 5, 6))
 
 
 def test_goaleval():

--- a/logpy/tests/test_core.py
+++ b/logpy/tests/test_core.py
@@ -2,10 +2,9 @@ import itertools
 import pytest
 from pytest import raises
 
-from logpy.core import (run, membero, fail, eq,
-                        conde, goaleval, lany, lallgreedy, lanyseq, goalexpand,
-                        earlyorder, EarlyGoalError, lall, earlysafe, lallfirst,
-                        condeseq)
+from logpy.core import (run, membero, fail, eq, conde, goaleval, lany,
+                        lallgreedy, lanyseq, goalexpand, earlyorder,
+                        EarlyGoalError, lall, earlysafe, lallfirst, condeseq)
 from logpy.util import transitive_get as walk
 from logpy.util import deep_transitive_get as walkstar
 from logpy.util import evalt

--- a/logpy/tests/test_core.py
+++ b/logpy/tests/test_core.py
@@ -2,13 +2,13 @@ import itertools
 import pytest
 from pytest import raises
 
-from logpy.core import (walk, walkstar, var, run,
-                        membero, evalt, fail, eq, conde,
-                        goaleval, lany, lallgreedy, lanyseq,
-                        goalexpand, earlyorder, EarlyGoalError, lall, earlysafe,
-                        lallfirst, condeseq)
+from logpy.core import (walk, walkstar, var, run, membero, evalt, fail, eq,
+                        conde, goaleval, lany, lallgreedy, lanyseq, goalexpand,
+                        earlyorder, EarlyGoalError, lall, earlysafe, lallfirst,
+                        condeseq)
 
 w, x, y, z = 'wxyz'
+
 
 def test_walk():
     s = {1: 2, 2: 3}
@@ -16,16 +16,19 @@ def test_walk():
     assert walk(1, s) == 3
     assert walk(4, s) == 4
 
+
 def test_deep_walk():
     """ Page 30 of Byrd thesis """
     s = {z: 6, y: 5, x: (y, z)}
     assert walk(x, s) == (y, z)
     assert walkstar(x, s) == (5, 6)
 
+
 def test_eq():
     x = var('x')
-    assert tuple(eq(x, 2)({})) == ({x: 2},)
+    assert tuple(eq(x, 2)({})) == ({x: 2}, )
     assert tuple(eq(x, 2)({x: 3})) == ()
+
 
 def test_lany():
     x = var('x')
@@ -38,74 +41,82 @@ def test_lany():
 @pytest.mark.parametrize('lall_impl', [lallgreedy, lall, lallfirst])
 def test_lall(lall_impl):
     x, y = var('x'), var('y')
-    assert results(lall_impl((eq, x, 2))) == ({x: 2},)
+    assert results(lall_impl((eq, x, 2))) == ({x: 2}, )
     assert results(lall_impl((eq, x, 2), (eq, x, 3))) == ()
-    assert results(lall_impl()) == ({},)
+    assert results(lall_impl()) == ({}, )
 
     assert run(0, x, lall_impl((eq, y, (1, 2)), (membero, x, y)))
-    assert run(0, x, lall_impl()) == (x,)
+    assert run(0, x, lall_impl()) == (x, )
     with pytest.raises(EarlyGoalError):
         run(0, x, lall_impl(membero(x, y)))
+
 
 @pytest.mark.parametrize('lall_impl', [lall, lallfirst])
 def test_safe_reordering_lall(lall_impl):
     x, y = var('x'), var('y')
     assert run(0, x, lall_impl((membero, x, y), (eq, y, (1, 2)))) == (1, 2)
 
+
 def test_earlysafe():
     x, y = var('x'), var('y')
     assert earlysafe((eq, 2, 2))
     assert earlysafe((eq, 2, 3))
-    assert earlysafe((membero, x, (1,2,3)))
+    assert earlysafe((membero, x, (1, 2, 3)))
     assert not earlysafe((membero, x, y))
+
 
 def test_earlyorder():
     x, y = var(), var()
-    assert earlyorder((eq, 2, x)) == ((eq, 2, x),)
+    assert earlyorder((eq, 2, x)) == ((eq, 2, x), )
     assert earlyorder((eq, 2, x), (eq, 3, x)) == ((eq, 2, x), (eq, 3, x))
-    assert earlyorder((membero, x, y), (eq, y, (1,2,3)))[0] == (eq, y, (1,2,3))
+    assert earlyorder(
+        (membero, x, y), (eq, y, (1, 2, 3)))[0] == (eq, y, (1, 2, 3))
+
 
 def test_conde():
     x = var('x')
     assert results(conde([eq(x, 2)], [eq(x, 3)])) == ({x: 2}, {x: 3})
     assert results(conde([eq(x, 2), eq(x, 3)])) == ()
 
+
 def test_condeseq():
     x = var('x')
     assert set(run(0, x, condeseq(([eq(x, 2)], [eq(x, 3)])))) == {2, 3}
     assert set(run(0, x, condeseq([[eq(x, 2), eq(x, 3)]]))) == set()
 
-    goals = ([eq(x, i)] for i in itertools.count()) # infinite number of goals
+    goals = ([eq(x, i)] for i in itertools.count())  # infinite number of goals
     assert run(1, x, condeseq(goals)) == (0, )
     assert run(1, x, condeseq(goals)) == (1, )
+
 
 def test_short_circuit():
     def badgoal(s):
         raise NotImplementedError()
 
     x = var('x')
-    tuple(run(5, x, fail, badgoal)) # Does not raise exception
+    tuple(run(5, x, fail, badgoal))  # Does not raise exception
+
 
 def test_run():
-    x,y,z = map(var, 'xyz')
-    assert run(1, x,  eq(x, 1)) == (1,)
-    assert run(2, x,  eq(x, 1)) == (1,)
-    assert run(0, x,  eq(x, 1)) == (1,)
-    assert run(1, x,  eq(x, (y, z)),
-                       eq(y, 3),
-                       eq(z, 4)) == ((3, 4),)
+    x, y, z = map(var, 'xyz')
+    assert run(1, x, eq(x, 1)) == (1, )
+    assert run(2, x, eq(x, 1)) == (1, )
+    assert run(0, x, eq(x, 1)) == (1, )
+    assert run(1, x, eq(x, (y, z)), eq(y, 3), eq(z, 4)) == ((3, 4), )
     assert set(run(2, x, conde([eq(x, 1)], [eq(x, 2)]))) == set((1, 2))
+
 
 def test_run_output_reify():
     x = var()
-    assert run(0, (1, 2, x), eq(x, 3)) == ((1, 2, 3),)
+    assert run(0, (1, 2, x), eq(x, 3)) == ((1, 2, 3), )
+
 
 def test_membero():
     x = var('x')
-    assert set(run(5, x, membero(x, (1,2,3)),
-                         membero(x, (2,3,4)))) == set((2,3))
+    assert set(run(5, x, membero(x, (1, 2, 3)), membero(x, (2, 3, 4)))) == set(
+        (2, 3))
 
-    assert run(5, x, membero(2, (1, x, 3))) == (2,)
+    assert run(5, x, membero(2, (1, x, 3))) == (2, )
     assert run(0, x, (membero, 1, (1, 2, 3))) == (x, )
     assert run(0, x, (membero, 1, (2, 3))) == ()
 
@@ -116,17 +127,20 @@ def test_lanyseq():
     assert list(goaleval(g)({})) == [{x: 0}, {x: 1}, {x: 2}]
     assert list(goaleval(g)({})) == [{x: 0}, {x: 1}, {x: 2}]
 
+
 def test_membero_can_be_reused():
     x = var('x')
     g = membero(x, (0, 1, 2))
     assert list(goaleval(g)({})) == [{x: 0}, {x: 1}, {x: 2}]
     assert list(goaleval(g)({})) == [{x: 0}, {x: 1}, {x: 2}]
 
+
 def test_evalt():
     add = lambda x, y: x + y
     assert evalt((add, 2, 3)) == 5
     assert evalt(add(2, 3)) == 5
-    assert evalt((1,2)) == (1,2)
+    assert evalt((1, 2)) == (1, 2)
+
 
 def test_uneval_membero():
     x, y = var('x'), var('y')
@@ -143,12 +157,13 @@ def test_goaleval():
         goaleval((membero, x, y))
     assert callable(goaleval((lallgreedy, (eq, x, 2))))
 
+
 def test_goalexpand():
     def growing_goal(*args):
         if len(args) < 10:
             return (growing_goal, 1) + tuple(args)
         else:
-            return lambda s: (1,)
+            return lambda s: (1, )
 
     g = (growing_goal, 2)
     assert goalexpand(g) == (growing_goal, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2)
@@ -157,11 +172,13 @@ def test_goalexpand():
 def test_lany_is_early_safe():
     x = var()
     y = var()
-    assert run(0, x, lany((membero, x, y), (eq, x, 2))) == (2,)
+    assert run(0, x, lany((membero, x, y), (eq, x, 2))) == (2, )
+
 
 def results(g, s={}):
     return tuple(goaleval(g)(s))
 
+
 def test_dict():
     x = var()
-    assert run(0, x, eq({1: x}, {1: 2})) == (2,)
+    assert run(0, x, eq({1: x}, {1: 2})) == (2, )

--- a/logpy/tests/test_facts.py
+++ b/logpy/tests/test_facts.py
@@ -1,6 +1,7 @@
 from logpy.facts import Relation, fact, facts
 from logpy.core import var, run, conde, reify
 
+
 def test_relation():
     parent = Relation()
     fact(parent, "Homer", "Bart")
@@ -12,16 +13,17 @@ def test_relation():
 
     x = var('x')
     assert set(run(5, x, parent("Homer", x))) == set(("Bart", "Lisa"))
-    assert set(run(5, x, parent(x, "Bart")))  == set(("Homer", "Marge"))
+    assert set(run(5, x, parent(x, "Bart"))) == set(("Homer", "Marge"))
 
     def grandparent(x, z):
         y = var()
         return conde((parent(x, y), parent(y, z)))
 
-    assert set(run(5, x, grandparent(x, "Bart") )) == set(("Abe", "Jackie"))
+    assert set(run(5, x, grandparent(x, "Bart"))) == set(("Abe", "Jackie"))
 
     foo = Relation('foo')
     assert 'foo' in str(foo)
+
 
 def test_fact():
     rel = Relation()
@@ -33,13 +35,15 @@ def test_fact():
     assert (2, 3) in rel.facts
     assert (3, 4) in rel.facts
 
+
 def test_unify_variable_with_itself_should_not_unify():
     # Regression test for https://github.com/logpy/logpy/issues/33
     valido = Relation()
     fact(valido, "a", "b")
     fact(valido, "b", "a")
     x = var()
-    assert run(0,x, valido(x,x)) == ()
+    assert run(0, x, valido(x, x)) == ()
+
 
 def test_unify_variable_with_itself_should_unify():
     valido = Relation()
@@ -47,7 +51,8 @@ def test_unify_variable_with_itself_should_unify():
     fact(valido, 1, 0)
     fact(valido, 1, 1)
     x = var()
-    assert run(0,x, valido(x,x)) == (1,)
+    assert run(0, x, valido(x, x)) == (1, )
+
 
 def test_unify_tuple():
     # Tests that adding facts can be unified with unpacked versions of those
@@ -60,4 +65,4 @@ def test_unify_tuple():
     y = var()
     assert set(run(0, x, valido((x, y)))) == set([0, 1])
     assert set(run(0, (x, y), valido((x, y)))) == set([(0, 1), (1, 0), (1, 1)])
-    assert run(0,x, valido((x,x))) == (1,)
+    assert run(0, x, valido((x, x))) == (1, )

--- a/logpy/tests/test_facts.py
+++ b/logpy/tests/test_facts.py
@@ -1,5 +1,5 @@
 from logpy.facts import Relation, fact, facts
-from logpy.core import var, run, conde, reify
+from logpy.core import var, run, conde
 
 
 def test_relation():

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -1,38 +1,43 @@
 from pytest import raises
 
 from logpy.goals import (tailo, heado, appendo, seteq, conso, typo,
-        isinstanceo, permuteq)
+                         isinstanceo, permuteq)
 from logpy.core import var, run, eq, EarlyGoalError, goaleval, membero
+
 
 def results(g, s={}):
     return tuple(goaleval(g)(s))
 
+
 def test_heado():
     x, y = var('x'), var('y')
-    assert results(heado(x, (1,2,3))) == ({x: 1},)
-    assert results(heado(1, (x,2,3))) == ({x: 1},)
+    assert results(heado(x, (1, 2, 3))) == ({x: 1}, )
+    assert results(heado(1, (x, 2, 3))) == ({x: 1}, )
     assert results(heado(x, ())) == ()
     with raises(EarlyGoalError):
         heado(x, y)
 
+
 def test_tailo():
     x, y = var('x'), var('y')
-    assert results((tailo, x, (1,2,3))) == ({x: (2,3)},)
-    assert results((tailo, x, (1, ))) == ({x: ()},)
+    assert results((tailo, x, (1, 2, 3))) == ({x: (2, 3)}, )
+    assert results((tailo, x, (1, ))) == ({x: ()}, )
     assert results((tailo, x, ())) == ()
     with raises(EarlyGoalError):
         tailo(x, y)
+
 
 def test_conso():
     x = var()
     y = var()
     assert not results(conso(x, y, ()))
     assert results(conso(1, (2, 3), (1, 2, 3)))
-    assert results(conso(x, (2, 3), (1, 2, 3))) == ({x: 1},)
-    assert results(conso(1, (2, 3), x)) == ({x: (1, 2, 3)},)
-    assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)},)
-    assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)},)
+    assert results(conso(x, (2, 3), (1, 2, 3))) == ({x: 1}, )
+    assert results(conso(1, (2, 3), x)) == ({x: (1, 2, 3)}, )
+    assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)}, )
+    assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)}, )
     # assert tuple(conde((conso(x, y, z), (membero, x, z)))({}))
+
 
 def test_seteq():
     x = var('x')
@@ -43,20 +48,22 @@ def test_seteq():
     assert len(results(seteq(abc, x))) == 6
     assert len(results(seteq(x, abc))) == 6
     assert bca in run(0, x, seteq(abc, x))
-    assert results(seteq((1, 2, 3), (3, x, 1))) == ({x: 2},)
+    assert results(seteq((1, 2, 3), (3, x, 1))) == ({x: 2}, )
 
     assert run(0, (x, y), seteq((1, 2, x), (2, 3, y)))[0] == (3, 1)
     assert not run(0, (x, y), seteq((4, 5, x), (2, 3, y)))
 
+
 def test_permuteq():
     x = var('x')
-    assert results(permuteq((1,2,2), (2,1,2)))
-    assert not results(permuteq((1,2), (2,1,2)))
-    assert not results(permuteq((1,2,3), (2,1,2)))
-    assert not results(permuteq((1,2,1), (2,1,2)))
+    assert results(permuteq((1, 2, 2), (2, 1, 2)))
+    assert not results(permuteq((1, 2), (2, 1, 2)))
+    assert not results(permuteq((1, 2, 3), (2, 1, 2)))
+    assert not results(permuteq((1, 2, 1), (2, 1, 2)))
 
-    assert set(run(0, x, permuteq(x, (1,2,2)))) == set(
-            ((1,2,2), (2,1,2), (2,2,1)))
+    assert set(run(0, x, permuteq(x, (1, 2, 2)))) == set(((1, 2, 2), (2, 1, 2),
+                                                          (2, 2, 1)))
+
 
 def test_typo():
     x = var('x')
@@ -64,6 +71,7 @@ def test_typo():
     assert not results(typo(3.3, int))
     assert run(0, x, membero(x, (1, 'cat', 2.2, 'hat')), (typo, x, str)) ==\
             ('cat', 'hat')
+
 
 def test_isinstanceo():
     assert results(isinstanceo((3, int), True))
@@ -73,23 +81,22 @@ def test_isinstanceo():
 
 def test_conso_early():
     x, y, z = var(), var(), var()
-    assert (run(0, x, (conso, x, y, z), (eq, z, (1, 2, 3)))
-            == (1,))
+    assert (run(0, x, (conso, x, y, z), (eq, z, (1, 2, 3))) == (1, ))
+
 
 def test_appendo():
     x, y, z, w = var('x'), var('y'), var('z'), var('w')
-    assert results(appendo((), (1,2), (1,2))) == ({},)
-    assert results(appendo((), (1,2), (1))) == ()
-    assert results(appendo((1,2), (3,4), (1,2,3,4)))
-    assert run(5, x, appendo((1,2,3), x, (1,2,3,4,5))) == ((4,5),)
-    assert run(5, x, appendo(x, (4, 5), (1, 2, 3, 4, 5))) == ((1, 2, 3),)
-    assert run(5, x, appendo((1, 2, 3), (4, 5), x)) == ((1, 2, 3, 4, 5),)
+    assert results(appendo((), (1, 2), (1, 2))) == ({}, )
+    assert results(appendo((), (1, 2), (1))) == ()
+    assert results(appendo((1, 2), (3, 4), (1, 2, 3, 4)))
+    assert run(5, x, appendo((1, 2, 3), x, (1, 2, 3, 4, 5))) == ((4, 5), )
+    assert run(5, x, appendo(x, (4, 5), (1, 2, 3, 4, 5))) == ((1, 2, 3), )
+    assert run(5, x, appendo((1, 2, 3), (4, 5), x)) == ((1, 2, 3, 4, 5), )
 
     for t in [tuple(range(i)) for i in range(5)]:
         for xi, yi in run(0, (x, y), appendo(x, y, t)):
             assert xi + yi == t
 
-        for xi, yi, zi in run(0, (x, y, z),
-                              appendo(x, y, w),
+        for xi, yi, zi in run(0, (x, y, z), appendo(x, y, w),
                               appendo(w, z, t)):
             assert xi + yi + zi == t

--- a/logpy/tests/test_term.py
+++ b/logpy/tests/test_term.py
@@ -1,5 +1,5 @@
 from logpy.term import term, operator, arguments, unifiable_with_term
-from logpy import var, unify, reify
+from logpy import var, unify
 from logpy.dispatch import dispatch
 
 

--- a/logpy/tests/test_term.py
+++ b/logpy/tests/test_term.py
@@ -2,6 +2,7 @@ from logpy.term import term, operator, arguments, unifiable_with_term
 from logpy import var, unify, reify
 from logpy.dispatch import dispatch
 
+
 def test_arguments():
     assert arguments(('add', 1, 2, 3)) == (1, 2, 3)
 
@@ -18,25 +19,31 @@ class Op(object):
     def __init__(self, name):
         self.name = name
 
+
 @unifiable_with_term
 class MyTerm(object):
     def __init__(self, op, arguments):
         self.op = op
         self.arguments = arguments
+
     def __eq__(self, other):
         return self.op == other.op and self.arguments == other.arguments
+
 
 @dispatch(MyTerm)
 def arguments(t):
     return t.arguments
 
+
 @dispatch(MyTerm)
 def operator(t):
     return t.op
 
+
 @dispatch(Op, (list, tuple))
 def term(op, args):
     return MyTerm(op, args)
+
 
 def test_unifiable_with_term():
     add = Op('add')
@@ -47,4 +54,3 @@ def test_unifiable_with_term():
 
     x = var('x')
     assert unify(MyTerm(add, (1, x)), MyTerm(add, (1, 2)), {}) == {x: 2}
-

--- a/logpy/tests/test_unification.py
+++ b/logpy/tests/test_unification.py
@@ -1,6 +1,7 @@
 from logpy.unification import unify, reify, _unify, _reify
 from logpy import var
 
+
 def test_reify():
     x, y, z = var(), var(), var()
     s = {x: 1, y: 2, z: (x, y)}
@@ -10,17 +11,20 @@ def test_reify():
     assert reify((1, (x, (y, 2))), s) == (1, (1, (2, 2)))
     assert reify(z, s) == (1, 2)
 
+
 def test_reify_dict():
     x, y = var(), var()
     s = {x: 2, y: 4}
     e = {1: x, 3: {5: y}}
     assert reify(e, s) == {1: 2, 3: {5: 4}}
 
+
 def test_reify_list():
     x, y = var(), var()
     s = {x: 2, y: 4}
     e = [1, [x, 3], y]
     assert reify(e, s) == [1, [2, 3], 4]
+
 
 def test_reify_complex():
     x, y = var(), var()
@@ -29,11 +33,13 @@ def test_reify_complex():
 
     assert reify(e, s) == {1: [2], 3: (4, 5)}
 
+
 def test_unify():
     assert unify(1, 1, {}) == {}
     assert unify(1, 2, {}) == False
     assert unify(var(1), 2, {}) == {var(1): 2}
     assert unify(2, var(1), {}) == {var(1): 2}
+
 
 def test_unify_seq():
     assert unify((1, 2), (1, 2), {}) == {}
@@ -42,12 +48,14 @@ def test_unify_seq():
     assert unify((1, var(1)), (1, 2), {}) == {var(1): 2}
     assert unify((1, var(1)), (1, 2), {var(1): 3}) == False
 
+
 def test_unify_dict():
     assert unify({1: 2}, {1: 2}, {}) == {}
     assert unify({1: 2}, {1: 3}, {}) == False
     assert unify({2: 2}, {1: 2}, {}) == False
     assert unify({1: 2, 3: 4}, {1: 2}, {}) == False
     assert unify({1: var(5)}, {1: 2}, {}) == {var(5): 2}
+
 
 def test_unify_complex():
     assert unify((1, {2: 3}), (1, {2: 3}), {}) == {}

--- a/logpy/tests/test_unification.py
+++ b/logpy/tests/test_unification.py
@@ -1,9 +1,10 @@
-from logpy.unification import unify, reify, _unify, _reify
+from logpy.unification import unify, reify
 from logpy import var
+
+x, y, z = var('x'), var('y'), var('z')
 
 
 def test_reify():
-    x, y, z = var(), var(), var()
     s = {x: 1, y: 2, z: (x, y)}
     assert reify(x, s) == 1
     assert reify(10, s) == 10
@@ -13,21 +14,18 @@ def test_reify():
 
 
 def test_reify_dict():
-    x, y = var(), var()
     s = {x: 2, y: 4}
     e = {1: x, 3: {5: y}}
     assert reify(e, s) == {1: 2, 3: {5: 4}}
 
 
 def test_reify_list():
-    x, y = var(), var()
     s = {x: 2, y: 4}
     e = [1, [x, 3], y]
     assert reify(e, s) == [1, [2, 3], 4]
 
 
 def test_reify_complex():
-    x, y = var(), var()
     s = {x: 2, y: 4}
     e = {1: [x], 3: (y, 5)}
 

--- a/logpy/tests/test_unifymore.py
+++ b/logpy/tests/test_unifymore.py
@@ -86,7 +86,6 @@ def test_unify_slice():
 
 
 def test_reify_slice():
-    x = var('x')
     assert reify(slice(1, var(2), 3), {var(2): 10}) == slice(1, 10, 3)
 
 
@@ -165,7 +164,7 @@ def test_unifiable():
 
 
 def test_reify_object_slots():
-    x, y, z = var('x'), var('y'), var('z')
+    x, y = var('x'), var('y')
     f, g = Aslot(1, 2), Aslot(x, y)
     assert reify_object_slots(g, {x: 1, y: 2}) == f
     assert reify_object_slots(g, {x: 1}) == Aslot(1, y)

--- a/logpy/tests/test_unifymore.py
+++ b/logpy/tests/test_unifymore.py
@@ -1,22 +1,25 @@
-from logpy.unifymore import (unify_object, reify_object,
-        reify_object_attrs, reify_object_slots, unify_object_attrs, unifiable)
+from logpy.unifymore import (unify_object, reify_object, reify_object_attrs,
+                             reify_object_slots, unify_object_attrs, unifiable)
 from logpy import var, run, eq
 from logpy.unification import unify, reify, _unify, _reify
 from logpy import variables
 
+
 class Foo(object):
-        def __init__(self, a, b):
-            self.a = a
-            self.b = b
-        def __eq__(self, other):
-            return (self.a, self.b) == (other.a, other.b)
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    def __eq__(self, other):
+        return (self.a, self.b) == (other.a, other.b)
 
 
 class Bar(object):
-        def __init__(self, c):
-            self.c = c
-        def __eq__(self, other):
-            return self.c == other.c
+    def __init__(self, c):
+        self.c = c
+
+    def __eq__(self, other):
+        return self.c == other.c
 
 
 def test_run_objects_with_context_manager():
@@ -26,8 +29,8 @@ def test_run_objects_with_context_manager():
     _reify.add((Foo, dict), reify_object)
     with variables(1234):
         assert unify_object(f, g, {})
-        assert run(1, 1234, (eq, f, g)) == (2,)
-        assert run(1, Foo(1234, 1234), (eq, f, g)) == (Foo(2, 2),)
+        assert run(1, 1234, (eq, f, g)) == (2, )
+        assert run(1, Foo(1234, 1234), (eq, f, g)) == (Foo(2, 2), )
 
 
 def test_unify_object():
@@ -53,8 +56,11 @@ def test_objects_full():
     _reify.add((Bar, dict), reify_object)
 
     assert unify_object(Foo(1, Bar(2)), Foo(1, Bar(var(3))), {}) == {var(3): 2}
-    assert reify(Foo(var('a'), Bar(Foo(var('b'), 3))),
-                 {var('a'): 1, var('b'): 2}) == Foo(1, Bar(Foo(2, 3)))
+    assert reify(
+        Foo(
+            var('a'), Bar(Foo(
+                var('b'), 3))), {var('a'): 1,
+                                 var('b'): 2}) == Foo(1, Bar(Foo(2, 3)))
 
 
 def test_list_1():
@@ -64,10 +70,10 @@ def test_list_1():
     x = var('x')
     y = var('y')
     rval = run(0, (x, y), (eq, Foo(1, [2]), Foo(x, [y])))
-    assert rval == ((1, 2),)
+    assert rval == ((1, 2), )
 
     rval = run(0, (x, y), (eq, Foo(1, [2]), Foo(x, y)))
-    assert rval == ((1, [2]),)
+    assert rval == ((1, [2]), )
 
 
 def test_unify_slice():
@@ -97,13 +103,15 @@ def test_reify_object_attrs():
     f, g = Foo(1, 2), Foo(x, y)
     s = {x: 1, y: 2}
     assert reify_object_attrs(g, s, ['a', 'b']) == f
-    assert reify_object_attrs(g, s, ['a']) ==  Foo(1, y)
-    assert reify_object_attrs(g, s, ['b']) ==  Foo(x, 2)
+    assert reify_object_attrs(g, s, ['a']) == Foo(1, y)
+    assert reify_object_attrs(g, s, ['b']) == Foo(x, 2)
     assert reify_object_attrs(g, s, []) is g
 
 
 def test_unify_isinstance_list():
-    class Foo2(Foo): pass
+    class Foo2(Foo):
+        pass
+
     x = var('x')
     y = var('y')
     f, g = Foo2(1, 2), Foo2(x, y)
@@ -136,6 +144,7 @@ def test_unifiable():
 @unifiable
 class Aslot(object):
     __slots__ = 'a', 'b'
+
     def __init__(self, a, b):
         self.a = a
         self.b = b
@@ -154,10 +163,11 @@ def test_unifiable():
     assert unify(f, g, {}) == {x: 2}
     assert reify(g, {x: 2}) == f
 
+
 def test_reify_object_slots():
     x, y, z = var('x'), var('y'), var('z')
     f, g = Aslot(1, 2), Aslot(x, y)
     assert reify_object_slots(g, {x: 1, y: 2}) == f
-    assert reify_object_slots(g, {x: 1}) ==  Aslot(1, y)
-    assert reify_object_slots(g, {y: 2}) ==  Aslot(x, 2)
+    assert reify_object_slots(g, {x: 1}) == Aslot(1, y)
+    assert reify_object_slots(g, {y: 2}) == Aslot(x, 2)
     assert reify_object_slots(g, {}) is g

--- a/logpy/tests/test_util.py
+++ b/logpy/tests/test_util.py
@@ -1,31 +1,38 @@
-from logpy.util import (take, unique, interleave, intersection,
-        groupsizes, dicthash, hashable, multihash)
+from logpy.util import (take, unique, interleave, intersection, groupsizes,
+                        dicthash, hashable, multihash)
+
 
 def test_hashable():
     assert hashable(2)
-    assert hashable((2,3))
+    assert hashable((2, 3))
     assert not hashable({1: 2})
     assert not hashable((1, {2: 3}))
 
+
 def test_unique():
-    assert tuple(unique((1,2,3))) == (1,2,3)
-    assert tuple(unique((1,2,1,3))) == (1,2,3)
+    assert tuple(unique((1, 2, 3))) == (1, 2, 3)
+    assert tuple(unique((1, 2, 1, 3))) == (1, 2, 3)
+
 
 def test_unique_dict():
     assert tuple(unique(({1: 2}, {2: 3}), key=dicthash)) == ({1: 2}, {2: 3})
-    assert tuple(unique(({1: 2}, {1: 2}), key=dicthash)) == ({1: 2},)
+    assert tuple(unique(({1: 2}, {1: 2}), key=dicthash)) == ({1: 2}, )
+
 
 def test_unique_not_hashable():
     assert tuple(unique(([1], [1])))
+
 
 def test_multihash():
     inputs = 2, (1, 2), [1, 2], {1: 2}, (1, [2]), slice(1, 2)
     assert all(isinstance(multihash(i), int) for i in inputs)
 
-def test_intersection():
-    a,b,c = (1,2,3,4), (2,3,4,5), (3,4,5,6)
 
-    assert tuple(intersection(a,b,c)) == (3,4)
+def test_intersection():
+    a, b, c = (1, 2, 3, 4), (2, 3, 4, 5), (3, 4, 5, 6)
+
+    assert tuple(intersection(a, b, c)) == (3, 4)
+
 
 def test_take():
     assert take(2, range(5)) == (0, 1)
@@ -33,12 +40,14 @@ def test_take():
     seq = range(5)
     assert take(None, seq) == seq
 
+
 def test_interleave():
     assert ''.join(interleave(('ABC', '123'))) == 'A1B2C3'
     assert ''.join(interleave(('ABC', '1'))) == 'A1BC'
 
+
 def test_groupsizes():
     assert set(groupsizes(4, 2)) == set(((1, 3), (2, 2), (3, 1)))
     assert set(groupsizes(5, 2)) == set(((1, 4), (2, 3), (3, 2), (4, 1)))
-    assert set(groupsizes(4, 1)) == set([(4,)])
+    assert set(groupsizes(4, 1)) == set([(4, )])
     assert set(groupsizes(4, 4)) == set([(1, 1, 1, 1)])

--- a/logpy/tests/test_variable.py
+++ b/logpy/tests/test_variable.py
@@ -1,21 +1,26 @@
 from logpy.variable import isvar, var, vars, variables
 
+
 def test_isvar():
     assert not isvar(3)
     assert isvar(var(3))
+
 
 def test_var():
     assert var(1) == var(1)
     assert var() != var()
 
+
 def test_var_inputs():
     assert var(1) == var(1)
     assert var() != var()
+
 
 def test_vars():
     vs = vars(3)
     assert len(vs) == 3
     assert all(map(isvar, vs))
+
 
 def test_context_manager():
     with variables(1):

--- a/logpy/unification.py
+++ b/logpy/unification.py
@@ -1,7 +1,6 @@
 from functools import partial
 from .util import transitive_get as walk
-from .variable import Var, var, isvar
-import itertools as it
+from .variable import isvar
 from .dispatch import dispatch
 from collections import Iterator
 from toolz.compatibility import iteritems, map
@@ -40,7 +39,7 @@ def _reify(o, s):
 def reify(e, s):
     """ Replace variables of expression with substitution
 
-    >>> from logpy.unification import reify, var
+    >>> from logpy.variable import var
     >>> x, y = var(), var()
     >>> e = (1, x, (3, y))
     >>> s = {x: 2, y: 4}
@@ -96,7 +95,7 @@ def _unify(u, v, s):
 def unify(u, v, s):  # no check at the moment
     """ Find substitution so that u == v while satisfying s
 
-    >>> from logpy.unification import unify, var
+    >>> from logpy.variable import var
     >>> x = var('x')
     >>> unify((1, x), (1, 2), {})
     {~x: 2}

--- a/logpy/unification.py
+++ b/logpy/unification.py
@@ -7,14 +7,13 @@ from collections import Iterator
 from toolz.compatibility import iteritems, map
 from toolz import assoc
 
-################
-# Reificiation #
-################
+###############
+# Reification #
+###############
 
 @dispatch(Iterator, dict)
 def _reify(t, s):
     return map(partial(reify, s=s), t)
-    # return (reify(arg, s) for arg in t)
 
 @dispatch(tuple, dict)
 def _reify(t, s):

--- a/logpy/unification.py
+++ b/logpy/unification.py
@@ -11,21 +11,26 @@ from toolz import assoc
 # Reification #
 ###############
 
+
 @dispatch(Iterator, dict)
 def _reify(t, s):
     return map(partial(reify, s=s), t)
+
 
 @dispatch(tuple, dict)
 def _reify(t, s):
     return tuple(reify(iter(t), s))
 
+
 @dispatch(list, dict)
 def _reify(t, s):
     return list(reify(iter(t), s))
 
+
 @dispatch(dict, dict)
 def _reify(d, s):
     return dict((k, reify(v, s)) for k, v in d.items())
+
 
 @dispatch(object, dict)
 def _reify(o, s):
@@ -55,6 +60,7 @@ def reify(e, s):
 ###############
 
 seq = tuple, list, Iterator
+
 
 @dispatch(seq, seq, dict)
 def _unify(u, v, s):

--- a/logpy/unifymore.py
+++ b/logpy/unifymore.py
@@ -98,17 +98,18 @@ def reify_object_attrs(o, s, attrs):
     """
     obj = object.__new__(type(o))
     d = dict(zip(attrs, [getattr(o, attr) for attr in attrs]))
-    d2 = reify(d, s)                             # reified attr dict
+    d2 = reify(d, s)  # reified attr dict
     if d2 == d:
         return o
 
-    obj.__dict__.update(o.__dict__)                   # old dict
-    obj.__dict__.update(d2)                           # update w/ reified vals
+    obj.__dict__.update(o.__dict__)  # old dict
+    obj.__dict__.update(d2)  # update w/ reified vals
     return obj
 
 #########
 # Unify #
 #########
+
 
 @dispatch(slice, slice, dict)
 def _unify(u, v, s):
@@ -143,9 +144,9 @@ def unify_object(u, v, s):
 
 def unify_object_slots(u, v, s):
     return unify(
-        tuple(getattr(u, a) for a in u.__slots__),
-        tuple(getattr(v, a) for a in v.__slots__),
-        s)
+        tuple(getattr(u, a)
+              for a in u.__slots__), tuple(getattr(v, a)
+                                           for a in v.__slots__), s)
 
 
 def unify_object_attrs(u, v, s, attrs):
@@ -176,15 +177,14 @@ def unify_object_attrs(u, v, s, attrs):
 
     attrs contains the list of attributes which participate in reificiation
     """
-    return unify([getattr(u, a) for a in attrs],
-                 [getattr(v, a) for a in attrs],
-                 s)
-
+    return unify([getattr(u, a) for a in attrs], [getattr(v, a)
+                                                  for a in attrs], s)
 
 # Registration
 
+
 def register_reify_object_attrs(cls, attrs):
-    _reify.add((cls,), partial(reify_object_attrs, attrs=attrs))
+    _reify.add((cls, ), partial(reify_object_attrs, attrs=attrs))
 
 
 def register_unify_object(cls):

--- a/logpy/unifymore.py
+++ b/logpy/unifymore.py
@@ -144,9 +144,9 @@ def unify_object(u, v, s):
 
 def unify_object_slots(u, v, s):
     return unify(
-        tuple(getattr(u, a)
-              for a in u.__slots__), tuple(getattr(v, a)
-                                           for a in v.__slots__), s)
+        tuple(getattr(u, a) for a in u.__slots__),
+        tuple(getattr(v, a) for a in v.__slots__),
+        s)
 
 
 def unify_object_attrs(u, v, s, attrs):
@@ -177,8 +177,10 @@ def unify_object_attrs(u, v, s, attrs):
 
     attrs contains the list of attributes which participate in reificiation
     """
-    return unify([getattr(u, a) for a in attrs], [getattr(v, a)
-                                                  for a in attrs], s)
+    return unify(
+        tuple(getattr(u, a) for a in attrs),
+        tuple(getattr(v, a) for a in attrs),
+        s)
 
 # Registration
 

--- a/logpy/util.py
+++ b/logpy/util.py
@@ -1,12 +1,14 @@
 import itertools as it
 from toolz.compatibility import range, map, iteritems
 
+
 def hashable(x):
     try:
         hash(x)
         return True
     except TypeError:
         return False
+
 
 def transitive_get(key, d):
     """ Transitive dict.get
@@ -21,6 +23,7 @@ def transitive_get(key, d):
     while hashable(key) and key in d:
         key = d[key]
     return key
+
 
 def deep_transitive_get(key, d):
     """ Transitive get that propagates within tuples
@@ -39,8 +42,10 @@ def deep_transitive_get(key, d):
     else:
         return key
 
+
 def dicthash(d):
     return hash(frozenset(d.items()))
+
 
 def multihash(x):
     try:
@@ -54,6 +59,7 @@ def multihash(x):
             return hash((x.start, x.stop, x.step))
         raise TypeError('Hashing not covered for ' + str(x))
 
+
 def unique(seq, key=lambda x: x):
     seen = set()
     for item in seq:
@@ -61,8 +67,9 @@ def unique(seq, key=lambda x: x):
             if key(item) not in seen:
                 seen.add(key(item))
                 yield item
-        except TypeError:   # item probably isn't hashable
-            yield item      # Just return it and hope for the best
+        except TypeError:  # item probably isn't hashable
+            yield item  # Just return it and hope for the best
+
 
 def interleave(seqs, pass_exceptions=()):
     iters = map(iter, seqs)
@@ -72,9 +79,10 @@ def interleave(seqs, pass_exceptions=()):
             try:
                 yield next(itr)
                 newiters.append(itr)
-            except (StopIteration,) + tuple(pass_exceptions):
+            except (StopIteration, ) + tuple(pass_exceptions):
                 pass
         iters = newiters
+
 
 def take(n, seq):
     if n is None:
@@ -100,9 +108,10 @@ def evalt(t):
     else:
         return t
 
+
 def intersection(*seqs):
-    return (item for item in seqs[0]
-                 if all(item in seq for seq in seqs[1:]))
+    return (item for item in seqs[0] if all(item in seq for seq in seqs[1:]))
+
 
 def groupsizes(total, len):
     """ Groups of length len that add up to total
@@ -112,11 +121,12 @@ def groupsizes(total, len):
     ((1, 3), (2, 2), (3, 1))
     """
     if len == 1:
-        yield (total,)
+        yield (total, )
     else:
         for i in range(1, total - len + 1 + 1):
             for perm in groupsizes(total - i, len - 1):
-                yield (i,) + perm
+                yield (i, ) + perm
+
 
 def pprint(g):
     """ Pretty print a tree of goals """
@@ -127,6 +137,7 @@ def pprint(g):
     if isinstance(g, tuple):
         return "(" + ', '.join(map(pprint, g)) + ")"
     return str(g)
+
 
 def index(tup, ind):
     """ Fancy indexing with tuples """

--- a/logpy/util.py
+++ b/logpy/util.py
@@ -1,5 +1,5 @@
 import itertools as it
-from toolz.compatibility import range, map, iteritems
+from toolz.compatibility import range, map
 
 
 def hashable(x):

--- a/logpy/variable.py
+++ b/logpy/variable.py
@@ -5,11 +5,13 @@ from .dispatch import dispatch
 _global_logic_variables = set()
 _glv = _global_logic_variables
 
+
 class Var(object):
     """ Logic Variable """
     __slots__ = ('token', )
 
     _id = 1
+
     def __init__(self, token=None):
         if token is None:
             token = "_%s" % Var._id
@@ -18,6 +20,7 @@ class Var(object):
 
     def __str__(self):
         return "~" + str(self.token)
+
     __repr__ = __str__
 
     def __eq__(self, other):
@@ -25,6 +28,7 @@ class Var(object):
 
     def __hash__(self):
         return hash((type(self), self.token))
+
 
 var = lambda *args: Var(*args)
 vars = lambda n: [var() for i in range(n)]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 install_command = pip install {opts} {packages}
-envlist = py27,py35
+envlist = py27,py35,lint
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -10,9 +10,10 @@ commands =
     rm -f .coverage
     py.test --cov=logpy -vv {posargs:logpy}
 basepython =
-    py26: python2.6
     py27: python2.7
     py35: python3.5
+    lint: python3.5
+    yapf: python3.5
 deps =
     -r{toxinidir}/requirements.txt
     coverage
@@ -21,3 +22,20 @@ deps =
     pytest-cov
 whitelist_externals =
     rm
+
+[testenv:lint]
+deps =
+    flake8
+commands =
+    flake8 logpy
+
+[testenv:yapf]
+# Tox target for autoformatting the code for pep8.
+deps =
+    yapf
+commands =
+    yapf --recursive logpy --in-place
+
+
+[flake8]
+ignore = E731,F811,E712

--- a/tox.ini
+++ b/tox.ini
@@ -38,4 +38,4 @@ commands =
 
 
 [flake8]
-ignore = E731,F811,E712
+ignore = E731,F811,E712,E127


### PR DESCRIPTION
This PR adds flake8 linting. This allowed me to clean up the imports and make the formatting more consistent. Most of the lint fixes were make with `yapf`.

There are no semantic changes, though some import paths no longer work. For most users of the library, importing directly from the `logpy.__init__` namespace is the preferred way anyway. If there are no objections in the next day or so, I'll merge.

## Note / TODO
- [ ] Other than a test, `deep_transitive_get` / `walkstar` seems to be unused. Determine if it should be used somewhere, and otherwise delete it.

