### PR TITLE
Enhanced conso

### DIFF
--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -203,7 +203,7 @@ class LCons(object):
 def _lcons_unify(lcons, t, s):
     if len(t) == 0:
         return False
-    return unify((lcons.head, lcons.tail), (t[0], t[1:]))
+    return unify((lcons.head, lcons.tail), (t[0], t[1:]), s)
 
 
 @unify.register((list, tuple), LCons, dict)

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -2,7 +2,7 @@ from itertools import permutations
 
 from unification import var, isvar, unify
 # TODO: we should be able to register new reification processes without
-# importing private methods. :-(
+# importing private methods.
 from unification.core import _reify
 from unification.more import unifiable, reify_object
 
@@ -11,44 +11,42 @@ from .core import (eq, EarlyGoalError, conde, condeseq, lany, lallgreedy, lall,
 from .util import unique
 
 
-def heado(x, coll):
-    """ x is the head of coll
+def heado(head, coll):
+    """ head is the head of coll
 
     See also:
         tailo
         conso
     """
-    if not isinstance(coll, tuple):
-        raise EarlyGoalError()
-    if isinstance(coll, tuple) and len(coll) >= 1:
-        return (eq, x, coll[0])
+    if isinstance(coll, (tuple, list)):
+        return (fail if len(coll) == 0 else (eq, head, coll[0]))
     else:
-        return fail
+        tail = var()
+        return (eq, LCons(head, tail), coll)
 
 
-def tailo(x, coll):
-    """ x is the tail of coll
+def tailo(tail, coll):
+    """ tail is the tail of coll
 
     See also:
         heado
         conso
     """
-    if not isinstance(coll, tuple):
-        raise EarlyGoalError()
-    if isinstance(coll, tuple) and len(coll) >= 1:
-        return (eq, x, coll[1:])
+    if isinstance(coll, (tuple, list)):
+        return (fail if len(coll) == 0 else (eq, tail, coll[1:]))
     else:
-        return fail
+        head = var()
+        return (eq, LCons(head, tail), coll)
 
 
 def conso(h, t, l):
     """ Logical cons -- l[0], l[1:] == h, t """
-    if isinstance(l, tuple):
+    if isinstance(l, (tuple, list)):
         if len(l) == 0:
             return fail
         else:
             return (conde, [(eq, h, l[0]), (eq, t, l[1:])])
-    elif isinstance(t, tuple):
+    elif isinstance(t, (tuple, list)):
         return eq((h, ) + t, l)
     else:
         return (eq, LCons(h, t), l)

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -1,3 +1,4 @@
+import collections
 from itertools import permutations
 
 from unification import var, isvar, unify
@@ -178,7 +179,7 @@ class LCons(object):
 
     def __iter__(self):
         yield self.head
-        if hasattr(self.tail, '__iter__'):
+        if isinstance(self.tail, collections.Iterable):
             for x in self.tail:
                 yield x
 

--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -178,6 +178,12 @@ class LCons(object):
     def __repr__(self):
         return 'LCons(%r, %r)' % (self.head, self.tail)
 
+    def __iter__(self):
+        yield self.head
+        if hasattr(self.tail, '__iter__'):
+            for x in self.tail:
+                yield x
+
     def __eq__(self, other):
         return (
             isinstance(other, LCons) and

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -1,9 +1,8 @@
-from pytest import raises
 from unification import unify
 
 from logpy.goals import (tailo, heado, appendo, seteq, conso, typo,
                          isinstanceo, permuteq, LCons)
-from logpy.core import var, run, eq, EarlyGoalError, goaleval, membero
+from logpy.core import var, run, eq, goaleval, membero
 
 x, y, z, w = var('x'), var('y'), var('z'), var('w')
 
@@ -16,16 +15,16 @@ def test_heado():
     assert results(heado(x, (1, 2, 3))) == ({x: 1}, )
     assert results(heado(1, (x, 2, 3))) == ({x: 1}, )
     assert results(heado(x, ())) == ()
-    with raises(EarlyGoalError):
-        heado(x, y)
+
+    assert run(0, x, (heado, x, z), (conso, 1, y, z)) == (1, )
 
 
 def test_tailo():
     assert results((tailo, x, (1, 2, 3))) == ({x: (2, 3)}, )
     assert results((tailo, x, (1, ))) == ({x: ()}, )
     assert results((tailo, x, ())) == ()
-    with raises(EarlyGoalError):
-        tailo(x, y)
+
+    assert run(0, y, (tailo, y, z), (conso, x, (1, 2), z)) == ((1, 2), )
 
 
 def test_conso():

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -4,13 +4,14 @@ from logpy.goals import (tailo, heado, appendo, seteq, conso, typo,
                          isinstanceo, permuteq)
 from logpy.core import var, run, eq, EarlyGoalError, goaleval, membero
 
+x, y, z, w = var('x'), var('y'), var('z'), var('w')
+
 
 def results(g, s={}):
     return tuple(goaleval(g)(s))
 
 
 def test_heado():
-    x, y = var('x'), var('y')
     assert results(heado(x, (1, 2, 3))) == ({x: 1}, )
     assert results(heado(1, (x, 2, 3))) == ({x: 1}, )
     assert results(heado(x, ())) == ()
@@ -19,7 +20,6 @@ def test_heado():
 
 
 def test_tailo():
-    x, y = var('x'), var('y')
     assert results((tailo, x, (1, 2, 3))) == ({x: (2, 3)}, )
     assert results((tailo, x, (1, ))) == ({x: ()}, )
     assert results((tailo, x, ())) == ()
@@ -28,8 +28,6 @@ def test_tailo():
 
 
 def test_conso():
-    x = var()
-    y = var()
     assert not results(conso(x, y, ()))
     assert results(conso(1, (2, 3), (1, 2, 3)))
     assert results(conso(x, (2, 3), (1, 2, 3))) == ({x: 1}, )
@@ -40,8 +38,6 @@ def test_conso():
 
 
 def test_seteq():
-    x = var('x')
-    y = var('y')
     abc = tuple('abc')
     bca = tuple('bca')
     assert results(seteq(abc, bca))
@@ -55,7 +51,6 @@ def test_seteq():
 
 
 def test_permuteq():
-    x = var('x')
     assert results(permuteq((1, 2, 2), (2, 1, 2)))
     assert not results(permuteq((1, 2), (2, 1, 2)))
     assert not results(permuteq((1, 2, 3), (2, 1, 2)))
@@ -66,7 +61,6 @@ def test_permuteq():
 
 
 def test_typo():
-    x = var('x')
     assert results(typo(3, int))
     assert not results(typo(3.3, int))
     assert run(0, x, membero(x, (1, 'cat', 2.2, 'hat')), (typo, x, str)) ==\
@@ -80,12 +74,10 @@ def test_isinstanceo():
 
 
 def test_conso_early():
-    x, y, z = var(), var(), var()
     assert (run(0, x, (conso, x, y, z), (eq, z, (1, 2, 3))) == (1, ))
 
 
 def test_appendo():
-    x, y, z, w = var('x'), var('y'), var('z'), var('w')
     assert results(appendo((), (1, 2), (1, 2))) == ({}, )
     assert results(appendo((), (1, 2), (1))) == ()
     assert results(appendo((1, 2), (3, 4), (1, 2, 3, 4)))
@@ -93,6 +85,8 @@ def test_appendo():
     assert run(5, x, appendo(x, (4, 5), (1, 2, 3, 4, 5))) == ((1, 2, 3), )
     assert run(5, x, appendo((1, 2, 3), (4, 5), x)) == ((1, 2, 3, 4, 5), )
 
+
+def test_appendo2():
     for t in [tuple(range(i)) for i in range(5)]:
         for xi, yi in run(0, (x, y), appendo(x, y, t)):
             assert xi + yi == t

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -34,7 +34,10 @@ def test_conso():
     assert results(conso(1, (2, 3), x)) == ({x: (1, 2, 3)}, )
     assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)}, )
     assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)}, )
+
     assert run(1, y, conso(1, x, y)) == (LCons(1, x), )
+    assert list(run(1, y, conso(1, x, y))[0]) == [1]
+    assert list(run(1, y, conso(1, x, y), conso(2, z, x))[0]) == [1, 2]
     # assert tuple(conde((conso(x, y, z), (membero, x, z)))({}))
 
 

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -1,7 +1,7 @@
 from pytest import raises
 
 from logpy.goals import (tailo, heado, appendo, seteq, conso, typo,
-                         isinstanceo, permuteq)
+                         isinstanceo, permuteq, LCons)
 from logpy.core import var, run, eq, EarlyGoalError, goaleval, membero
 
 x, y, z, w = var('x'), var('y'), var('z'), var('w')
@@ -34,6 +34,7 @@ def test_conso():
     assert results(conso(1, (2, 3), x)) == ({x: (1, 2, 3)}, )
     assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)}, )
     assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)}, )
+    assert run(1, y, conso(1, x, y)) == (LCons(1, x), )
     # assert tuple(conde((conso(x, y, z), (membero, x, z)))({}))
 
 
@@ -90,7 +91,6 @@ def test_appendo2():
     for t in [tuple(range(i)) for i in range(5)]:
         for xi, yi in run(0, (x, y), appendo(x, y, t)):
             assert xi + yi == t
-
-        for xi, yi, zi in run(0, (x, y, z), appendo(x, y, w),
-                              appendo(w, z, t)):
+        results = run(0, (x, y, z), (appendo, x, y, w), (appendo, w, z, t))
+        for xi, yi, zi in results:
             assert xi + yi + zi == t

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -1,4 +1,5 @@
 from pytest import raises
+from unification import unify
 
 from logpy.goals import (tailo, heado, appendo, seteq, conso, typo,
                          isinstanceo, permuteq, LCons)
@@ -39,6 +40,14 @@ def test_conso():
     assert list(run(1, y, conso(1, x, y))[0]) == [1]
     assert list(run(1, y, conso(1, x, y), conso(2, z, x))[0]) == [1, 2]
     # assert tuple(conde((conso(x, y, z), (membero, x, z)))({}))
+
+
+def test_lcons():
+    assert unify(LCons(1, ()), (x, )) == {x: 1}
+    assert unify(LCons(1, (x, )), (x, y)) == {x: 1, y: 1}
+    assert unify((x, y), LCons(1, (x, ))) == {x: 1, y: 1}
+    assert unify(LCons(x, y), ()) == False
+    assert list(LCons(1, LCons(2, x))) == [1, 2]
 
 
 def test_seteq():


### PR DESCRIPTION
Partial implementation of #46. This PR adds an `LCons` class, and updates the `conso` relation to use it. This increases the capabilities of `conso` significantly, and better matches the behavior of other successful minikanren implementations like `core.logic` in clojure.

 This is somewhat similar to the implementation in [core.logic](https://github.com/clojure/core.logic/blob/master/src/main/clojure/clojure/core/logic.clj), though using the unification machinery of the `unification` library instead.

## Usage examples

```
>>> unify(LCons(1, (x, )), (x, y))
{~x: 1, ~y: 1}
>>> run(1, y, conso(1, x, y), conso(2, z, x))[0]
LCons(1, LCons(2, ~z))
>>> list(_)
[1, 2]
```
Note that the `LCons` object has an `__iter__` method that stops when it runs into an unbound tail. I think this will make it easier to consume the results in practice. 

AFAICT, any cases where `run` returns a value like `LCons(1, LCons(2, ~1))`, then `(1, 2) == LCons(1, LCons(2, ()))` would actually satisfy all the goals that were provided, though I don't have a formal proof of that. If counterexamples are found, it might make sense to change that behavior.