### PR TITLE
Make conso a bit more user-friendly on the first goal found

### DIFF
--- a/logpy/goals.py
+++ b/logpy/goals.py
@@ -48,9 +48,19 @@ def conso(h, t, l):
         else:
             return (conde, [(eq, h, l[0]), (eq, t, l[1:])])
     elif isinstance(t, (tuple, list)):
-        return eq((h, ) + t, l)
+        return eq((h, ) + tuple(t), l)
     else:
-        return (eq, LCons(h, t), l)
+        return (
+            lall,
+
+            # The definition of conso. This means that l can be unified with
+            # an LCons object (head + tail).
+            (eq, LCons(h, t), l),
+
+            # A "type declaration" for the tail. This means that the first goal
+            # found will simplify to a list with no extra unbound variables.
+            (lany, (eq, t, ()), (eq, t, LCons(var(), var())))
+        )
 
 
 def permuteq(a, b, eq2=eq):

--- a/logpy/tests/test_goals.py
+++ b/logpy/tests/test_goals.py
@@ -35,9 +35,13 @@ def test_conso():
     assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)}, )
     assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)}, )
 
-    assert run(1, y, conso(1, x, y)) == (LCons(1, x), )
-    assert list(run(1, y, conso(1, x, y))[0]) == [1]
-    assert list(run(1, y, conso(1, x, y), conso(2, z, x))[0]) == [1, 2]
+    # Verify that the first goal that's found does not contain unbound logic
+    # variables.
+    assert run(1, y, conso(1, x, y))[0] == (1, )
+    # But (potentially infinitely many goals _are_ generated).
+    assert isinstance(run(2, y, conso(1, x, y))[1], LCons)
+
+    assert run(1, y, conso(1, x, y), conso(2, z, x))[0] == (1, 2)
     # assert tuple(conde((conso(x, y, z), (membero, x, z)))({}))
 
 


### PR DESCRIPTION
Minor usability enhancement to `conso`, declaring the form that the tail must take: either an empty tuple or a non-empty `LCons` object. This means that the first result from `run` defaults to a tuple, without needing to call the `__iter__` method.