### PR TITLE
Fix early goal evaluation

### DIFF
--- a/kanren/__init__.py
+++ b/kanren/__init__.py
@@ -12,4 +12,4 @@ from .goals import seteq, permuteq, goalify, membero
 from .facts import Relation, fact, facts
 from .term import arguments, operator, term, unifiable_with_term
 
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -297,5 +297,8 @@ def goaleval(goal):
     if callable(goal):  # goal is already a function like eq(x, 1)
         return goal
     if isinstance(goal, tuple):  # goal is not yet evaluated like (eq, x, 1)
-        return find_fixed_point(evalt, goal)
+        try:
+            return find_fixed_point(evalt, goal)
+        except Exception as e:
+            raise EarlyGoalError(e)
     raise TypeError("Expected either function or tuple")

--- a/kanren/tests/test_goals.py
+++ b/kanren/tests/test_goals.py
@@ -138,61 +138,17 @@ def test_appendo2():
 
 
 def test_goal_ordering():
-    def lefto(q, p, list):
-            # give me q such that q is left of p in list
-            # zip(list, list[1:]) gives a list of 2-tuples of neighboring combinations
-            # which can then be pattern-matched against the query
-            return membero((q,p), zip(list, list[1:]))
+    # Regression test for https://github.com/logpy/logpy/issues/58
 
-    def nexto(q, p, list):
-            # give me q such that q is next to p in list
-            # match lefto(q, p) OR lefto(p, q)
-            # requirement of vector args instead of tuples doesn't seem to be documented
-            return conde([lefto(q, p, list)], [lefto(p, q, list)])
+    def lefto(q, p, lst):
+        return membero((q, p), zip(lst, lst[1:]))
 
-    houses = var()
-
-    zebraRules = lall(
-            # there are 5 houses
-            (eq,            (var(), var(), var(), var(), var()), houses),
-            # the Englishman's house is red
-            (membero,       ('Englishman', var(), var(), var(), 'red'), houses),
-            # the Swede has a dog
-            (membero,       ('Swede', var(), var(), 'dog', var()), houses),
-            # the Dane drinks tea
-            (membero,       ('Dane', var(), 'tea', var(), var()), houses),
-            # the Green house is left of the White house
-            (lefto,         (var(), var(), var(), var(), 'green'),
-                                    (var(), var(), var(), var(), 'white'), houses),
-            # coffee is the drink of the green house
-            (membero,       (var(), var(), 'coffee', var(), 'green'), houses),
-            # the Pall Mall smoker has birds
-            (membero,       (var(), 'Pall Mall', var(), 'birds', var()), houses),
-            # the yellow house smokes Dunhills
-            (membero,       (var(), 'Dunhill', var(), var(), 'yellow'), houses),
-            # the middle house drinks milk
-            (eq,            (var(), var(), (var(), var(), 'milk', var(), var()), var(), var()), houses),
-            # the Norwegian is the first house
-            (eq,            (('Norwegian', var(), var(), var(), var()), var(), var(), var(), var()), houses),
-            # the Blend smoker is in the house next to the house with cats
-            (nexto,         (var(), 'Blend', var(), var(), var()),
-                                    (var(), var(), var(), 'cats', var()), houses),
-            # the Dunhill smoker is next to the house where they have a horse
-            (nexto,         (var(), 'Dunhill', var(), var(), var()),
-                                    (var(), var(), var(), 'horse', var()), houses),
-            # the Blue Master smoker drinks beer
-            (membero,       (var(), 'Blue Master', 'beer', var(), var()), houses),
-            # the German smokes Prince
-            (membero,       ('German', 'Prince', var(), var(), var()), houses),
-            # the Norwegian is next to the blue house
-            (nexto,         ('Norwegian', var(), var(), var(), var()),
-                                    (var(), var(), var(), var(), 'blue'), houses),
-            # the house next to the Blend smoker drinks water
-            (nexto,         (var(), 'Blend', var(), var(), var()),
-                                    (var(), var(), 'water', var(), var()), houses),
-            # one of the houses has a zebra--but whose?
-            (membero,       (var(), var(), var(), 'zebra', var()), houses)
+    vals = var()
+    rules = (
+        lall,
+        (eq, (var(), var()), vals),
+        (lefto, 'green', 'white', vals),
     )
 
-    solutions = run(0, houses, zebraRules)
-    zebraOwner = [house for house in solutions[0] if 'zebra' in house][0][0]
+    solution, = run(1, vals, rules)
+    assert solution == ('green', 'white')

--- a/kanren/tests/test_goals.py
+++ b/kanren/tests/test_goals.py
@@ -4,7 +4,7 @@ from unification import unify, var
 
 from ..goals import (tailo, heado, appendo, seteq, conso, typo,
                           isinstanceo, permuteq, LCons, membero)
-from ..core import run, eq, goaleval
+from ..core import run, eq, goaleval, lall
 
 x, y, z, w = var('x'), var('y'), var('z'), var('w')
 
@@ -135,3 +135,64 @@ def test_appendo2():
         results = run(0, (x, y, z), (appendo, x, y, w), (appendo, w, z, t))
         for xi, yi, zi in results:
             assert xi + yi + zi == t
+
+
+def test_goal_ordering():
+    def lefto(q, p, list):
+            # give me q such that q is left of p in list
+            # zip(list, list[1:]) gives a list of 2-tuples of neighboring combinations
+            # which can then be pattern-matched against the query
+            return membero((q,p), zip(list, list[1:]))
+
+    def nexto(q, p, list):
+            # give me q such that q is next to p in list
+            # match lefto(q, p) OR lefto(p, q)
+            # requirement of vector args instead of tuples doesn't seem to be documented
+            return conde([lefto(q, p, list)], [lefto(p, q, list)])
+
+    houses = var()
+
+    zebraRules = lall(
+            # there are 5 houses
+            (eq,            (var(), var(), var(), var(), var()), houses),
+            # the Englishman's house is red
+            (membero,       ('Englishman', var(), var(), var(), 'red'), houses),
+            # the Swede has a dog
+            (membero,       ('Swede', var(), var(), 'dog', var()), houses),
+            # the Dane drinks tea
+            (membero,       ('Dane', var(), 'tea', var(), var()), houses),
+            # the Green house is left of the White house
+            (lefto,         (var(), var(), var(), var(), 'green'),
+                                    (var(), var(), var(), var(), 'white'), houses),
+            # coffee is the drink of the green house
+            (membero,       (var(), var(), 'coffee', var(), 'green'), houses),
+            # the Pall Mall smoker has birds
+            (membero,       (var(), 'Pall Mall', var(), 'birds', var()), houses),
+            # the yellow house smokes Dunhills
+            (membero,       (var(), 'Dunhill', var(), var(), 'yellow'), houses),
+            # the middle house drinks milk
+            (eq,            (var(), var(), (var(), var(), 'milk', var(), var()), var(), var()), houses),
+            # the Norwegian is the first house
+            (eq,            (('Norwegian', var(), var(), var(), var()), var(), var(), var(), var()), houses),
+            # the Blend smoker is in the house next to the house with cats
+            (nexto,         (var(), 'Blend', var(), var(), var()),
+                                    (var(), var(), var(), 'cats', var()), houses),
+            # the Dunhill smoker is next to the house where they have a horse
+            (nexto,         (var(), 'Dunhill', var(), var(), var()),
+                                    (var(), var(), var(), 'horse', var()), houses),
+            # the Blue Master smoker drinks beer
+            (membero,       (var(), 'Blue Master', 'beer', var(), var()), houses),
+            # the German smokes Prince
+            (membero,       ('German', 'Prince', var(), var(), var()), houses),
+            # the Norwegian is next to the blue house
+            (nexto,         ('Norwegian', var(), var(), var(), var()),
+                                    (var(), var(), var(), var(), 'blue'), houses),
+            # the house next to the Blend smoker drinks water
+            (nexto,         (var(), 'Blend', var(), var(), var()),
+                                    (var(), var(), 'water', var(), var()), houses),
+            # one of the houses has a zebra--but whose?
+            (membero,       (var(), var(), var(), 'zebra', var()), houses)
+    )
+
+    solutions = run(0, houses, zebraRules)
+    zebraOwner = [house for house in solutions[0] if 'zebra' in house][0][0]

--- a/kanren/tests/test_goals.py
+++ b/kanren/tests/test_goals.py
@@ -4,7 +4,7 @@ from unification import unify, var
 
 from ..goals import (tailo, heado, appendo, seteq, conso, typo,
                           isinstanceo, permuteq, LCons, membero)
-from ..core import run, eq, goaleval, lall
+from ..core import run, eq, goaleval, lall, lallgreedy
 
 x, y, z, w = var('x'), var('y'), var('z'), var('w')
 
@@ -144,11 +144,25 @@ def test_goal_ordering():
         return membero((q, p), zip(lst, lst[1:]))
 
     vals = var()
-    rules = (
+
+    # Verify the solution can be computed when we specify the execution
+    # ordering.
+    rules_greedy = (
+        lallgreedy,
+        (eq, (var(), var()), vals),
+        (lefto, 'green', 'white', vals),
+    )
+
+    solution, = run(1, vals, rules_greedy)
+    assert solution == ('green', 'white')
+
+    # Verify that attempting to compute the "safe" order does not itself cause
+    # the evaluation to fail.
+    rules_greedy = (
         lall,
         (eq, (var(), var()), vals),
         (lefto, 'green', 'white', vals),
     )
 
-    solution, = run(1, vals, rules)
+    solution, = run(1, vals, rules_greedy)
     assert solution == ('green', 'white')


### PR DESCRIPTION
@kootenpv Fixes #58.

## The bug
Prior to 4cc6660be4a6be0bdd85900baf344d293b4948c7, the implementation of `lall` would evaluate goals in the order given. In #43, I renamed that to `lallgreedy`, and updated the implementation of `lall` to take the "safe" course of attempting to reorder the goals according to whether they could be evaluated given the current set of reifications being tested. That meant goals which were correctly ordered previously could now fail when attempting to evaluate whether goals later on would could be evaluated.

## The fix
I updated the evaluation of `goaleval` so that if its attempts to evaluate the goal fail, it considers that an `EarlyGoalError`. 

## Testing

I simplified the "zebra" example into a minimal example which reproduced the issue, and added that as a regression test. I also verified the "zebra" example passes with this patch.

## Issues with this patch

Considering exceptions in evaluating goals as "early goal evaluation" seems to generally match the semantics we'd want, but can lead to hiding bugs inside of confusing stack traces:
```pytb
>>> from kanren import *
>>> from kanren.core import lall
>>> def bugo(x):
...     assert False
... 
>>> x = var('x')    
>>> run(0, [x], (lall, (eq, x, 1), (bugo, x)))
Traceback (most recent call last):
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 301, in goaleval
    return find_fixed_point(evalt, goal)
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 285, in find_fixed_point
    cur = f(cur)
  File "/Users/lucaswiman/opensource/logpy/kanren/util.py", line 84, in evalt
    return t[0](*t[1:])
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 53, in lall
    return (lallgreedy, ) + tuple(earlyorder(*goals))
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 160, in earlyorder
    raise EarlyGoalError()
kanren.core.EarlyGoalError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 241, in run
    return take(n, unique(results, key=multihash))
  File "/Users/lucaswiman/opensource/logpy/kanren/util.py", line 68, in take
    return tuple(seq)
  File "/Users/lucaswiman/opensource/logpy/kanren/util.py", line 34, in unique
    for item in seq:
  File "/Users/lucaswiman/opensource/logpy/kanren/util.py", line 34, in unique
    for item in seq:
  File "/Users/lucaswiman/opensource/logpy/kanren/util.py", line 55, in interleave
    for itr in iters:
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 81, in <genexpr>
    (lallgreedy, ) + tuple(goals[1:]), ss))(ss) for ss in g(s)),
  File "/Users/lucaswiman/opensource/logpy/kanren/core.py", line 303, in goaleval
    raise EarlyGoalError(e)
kanren.core.EarlyGoalError
```
This is undesirable, but would require additional refactoring to fix. In the mean time, it avoids less-confusing-but-more-annoying issues with goals which cannot handle a `Var` as input. For goals in the `kanren` implementation, explicitly handling `Var` is fine, but it's less user-friendly for the public. 