### PR TITLE
Add validation for and generalize permuteq argument types

### DIFF
--- a/kanren/goals.py
+++ b/kanren/goals.py
@@ -1,6 +1,8 @@
-import collections
 import operator
+import collections
+
 from itertools import permutations
+from collections.abc import Sequence
 
 from unification import isvar, var, reify, unify
 
@@ -17,7 +19,7 @@ def heado(head, coll):
         tailo
         conso
     """
-    return (eq, cons(head, var()), coll)
+    return eq(cons(head, var()), coll)
 
 
 def tailo(tail, coll):
@@ -27,13 +29,13 @@ def tailo(tail, coll):
         heado
         conso
     """
-    return (eq, cons(var(), tail), coll)
+    return eq(cons(var(), tail), coll)
 
 
 def conso(h, t, l):
     """ cons h + t == l
     """
-    return (eq, cons(h, t), l)
+    return eq(cons(h, t), l)
 
 
 def nullo(l):
@@ -80,7 +82,7 @@ def permuteq(a, b, eq2=eq):
     >>> run(0, x, permuteq((2, 1, x), (2, 1, 2)))
     (2,)
     """
-    if isinstance(a, tuple) and isinstance(b, tuple):
+    if isinstance(a, Sequence) and isinstance(b, Sequence):
         if len(a) != len(b):
             return fail
         elif collections.Counter(a) == collections.Counter(b):
@@ -96,21 +98,24 @@ def permuteq(a, b, eq2=eq):
                     c.remove(x)
                 except ValueError:
                     pass
-            c, d = tuple(c), tuple(d)
+
             if len(c) == 1:
                 return (eq2, c[0], d[0])
             return condeseq(
                 ((eq2, x, d[0]), (permuteq, c[0:i] + c[i + 1:], d[1:], eq2))
                 for i, x in enumerate(c)
             )
+    elif not (isinstance(a, Sequence) or isinstance(b, Sequence)):
+        raise ValueError(
+            'Neither a nor b is a Sequence: {}, {}'.format(type(a), type(b)))
 
     if isvar(a) and isvar(b):
         raise EarlyGoalError()
 
     if isvar(a) or isvar(b):
-        if isinstance(b, tuple):
+        if isinstance(b, Sequence):
             c, d = a, b
-        elif isinstance(a, tuple):
+        elif isinstance(a, Sequence):
             c, d = b, a
 
         return (condeseq, ([eq(c, perm)]

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pytest
+
 from unification import var, isvar
 
 from kanren.goals import (tailo, heado, appendo, seteq, conso, typo,
@@ -99,12 +101,20 @@ def test_seteq():
 
 def test_permuteq():
     assert results(permuteq((1, 2), (2, 1)))
+    assert results(permuteq([1, 2], [2, 1]))
     assert results(permuteq((1, 2, 2), (2, 1, 2)))
+
+    with pytest.raises(ValueError):
+        permuteq(set((1, 2, 2)), set((2, 1, 2)))
+
     assert not results(permuteq((1, 2), (2, 1, 2)))
     assert not results(permuteq((1, 2, 3), (2, 1, 2)))
     assert not results(permuteq((1, 2, 1), (2, 1, 2)))
+    assert not results(permuteq([1, 2, 1], (2, 1, 2)))
 
     assert set(run(0, x, permuteq(x, (1, 2, 2)))) == set(((1, 2, 2), (2, 1, 2),
+                                                          (2, 2, 1)))
+    assert set(run(0, x, permuteq(x, [1, 2, 2]))) == set(((1, 2, 2), (2, 1, 2),
                                                           (2, 2, 1)))
 
 


### PR DESCRIPTION
`permuteq` does not validate its input arguments, so, when it's given non-tuple arguments, it fails&mdash;and most often outside the function itself.  Also, it's unnecessarily restricted to tuple inputs.  

This PR fixes those two problem.