### PR TITLE
Fixed collections module imports for python 3.10+

### DIFF
--- a/kanren/util.py
+++ b/kanren/util.py
@@ -1,5 +1,5 @@
 import itertools as it
-from collections import Hashable
+from collections.abc import Hashable
 
 from toolz.compatibility import range, map
 

--- a/tests/test_cons.py
+++ b/tests/test_cons.py
@@ -1,6 +1,7 @@
 from functools import reduce
 from itertools import chain, cycle
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 
 from kanren.cons import cons, ConsPair, car, cdr, is_cons, is_null
 


### PR DESCRIPTION
Changed `from collections import Iterable, Hashable` to `from collections.abc import Iterable, Hashable`.

Fixes #83